### PR TITLE
Remove dependency on any Java package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.prometheus.jmx4prometheus</groupId>
   <artifactId>jmx4prometheus</artifactId>
   <packaging>jar</packaging>
-  <version>0.2</version>
+  <version>0.3</version>
   <name>jmx4prometheus</name>
   <description>
     See https://github.com/prometheus/jmx4prometheus/blob/master/README.md
@@ -57,7 +57,7 @@
         </configuration>
       </plugin>
 
-      <!-- Build a full jar with dependencies --> 
+      <!-- Build a full jar with dependencies -->
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/src/deb/control/control
+++ b/src/deb/control/control
@@ -3,7 +3,7 @@ Version: [[version]]
 Section: misc
 Priority: optional
 Architecture: all
-Depends: sun-java6-jre | sun-java6-sdk | openjdk-6-jre | openjdk-6-jdk
+Depends:
 Maintainer: Conor Hennessy <conor@soundcloud.com>
 Description: expose jmx values as json webserver
 Distribution: development


### PR DESCRIPTION
There are many ways to install Java on a server. Removing the dependency line makes it easier to use this package.

@typingduck @juliusv 