### PR TITLE
Support lowercasing names and labels. Allow for empty labels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The configuration is in JSON. An example with all possible options:
 ```
 { 
   "hostPort": "127.0.0.1:1234",
+  "lowercaseOutputName": false,
+  "lowercaseOutputLabelNames": false,
   "rules": [
     {"pattern": "^org.apache.cassandra.metrics<type=(\w+), name=(\w+)><>Value:",
      "name": "cassandra_$1_$2",
@@ -36,11 +38,13 @@ The configuration is in JSON. An example with all possible options:
 Name     | Description
 ---------|------------
 hostPort | The host and port to connect to via remote JMX. If not specified, will talk to the local JVM.
+lowercaseOutputName | Lowercase the output metric name. Applies to default format and `name`. Defaults to false.
+lowercaseOutputLabelNames | Lowercase the output metric label names. Applies to default format and `labels`. Defaults to false.
 rules    | A list of rules to apply in order, processing stops at the first matching rule. Attributes that aren't matched aren't collected. If not specified, defaults to collecting everything in the default format.
 pattern  | Regex pattern to match against each bean attribute. The pattern is not anchored. Capture groups can be used in other options. Defaults to matching everything.
-attrNameSnakeCase | Converts the attribute name to snake case. This is seen in the names matched by the pattern and the default format. For example, anAttrName to an\_attr\_name.
+attrNameSnakeCase | Converts the attribute name to snake case. This is seen in the names matched by the pattern and the default format. For example, anAttrName to an\_attr\_name. Defaults to false.
 name     | The metric name to set. Capture groups from the `pattern` can be used. If not specified, the default format will be used.
-labels   | A map of label name to label value pairs. Capture groups from `pattern` can be used in each. `name` must be set to use this. If not specified and the default format is not being used, no labels are set.
+labels   | A map of label name to label value pairs. Capture groups from `pattern` can be used in each. `name` must be set to use this. Empty names and values are ignored. If not specified and the default format is not being used, no labels are set.
 help     | Help text for the metric. Capture groups from `pattern` can be used. `name` must be set to use this. Defaults to the mBean attribute decription and the full name of the attribute.
 type     | The type of the metric, can be `GAUGE` or `COUNTER`. `name` must be set to use this. Defaults to `GAUGE`.
 

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -74,6 +74,27 @@ public class JmxCollectorTest {
     }
 
     @Test
+    public void testEmptyLabelsAreIgnored() throws ParseException {
+      JmxCollector jc = new JmxCollector(
+          "{`rules`: [{`pattern`: `^hadoop<service=DataNode, name=DataNodeActivity-ams-hdd001-50010><>replaceBlockOpMinTime:`, `name`: `foo`, `labels`: {``: `v`, `l`: ``}}]}".replace('`', '"')).register(registry);
+      assertEquals(200, registry.getSampleValue("foo", new String[]{}, new String[]{}), .001);
+    }
+
+    @Test
+    public void testLowercaseOutputName() throws ParseException {
+      JmxCollector jc = new JmxCollector(
+          "{`lowercaseOutputName`: true, `rules`: [{`pattern`: `^hadoop<service=DataNode, name=DataNodeActivity-ams-hdd001-50010><>replaceBlockOpMinTime:`, `name`: `Foo`}]}".replace('`', '"')).register(registry);
+      assertEquals(200, registry.getSampleValue("foo", new String[]{}, new String[]{}), .001);
+    }
+
+    @Test
+    public void testLowercaseOutputLabelNames() throws ParseException {
+      JmxCollector jc = new JmxCollector(
+          "{`lowercaseOutputLabelNames`: true, `rules`: [{`pattern`: `^hadoop<service=DataNode, name=DataNodeActivity-ams-hdd001-50010><>replaceBlockOpMinTime:`, `name`: `Foo` , `labels`: {`ABC`: `DEF`}}]}".replace('`', '"')).register(registry);
+      assertEquals(200, registry.getSampleValue("Foo", new String[]{"abc"}, new String[]{"DEF"}), .001);
+    }
+
+    @Test
     public void testNameAndLabelsFromPattern() throws ParseException {
       JmxCollector jc = new JmxCollector(
           "{`rules`: [{`pattern`: `^hadoop<(service)=(DataNode), name=DataNodeActivity-ams-hdd001-50010><>(replaceBlockOpMinTime):`, `name`: `hadoop_$3`, `labels`: {`$1`: `$2`}}]}".replace('`', '"')).register(registry);
@@ -121,6 +142,12 @@ public class JmxCollectorTest {
 
       // Test Hadoop Metrics.
       assertEquals(200, registry.getSampleValue("hadoop_DataNode_replaceBlockOpMinTime", new String[]{"name"}, new String[]{"DataNodeActivity-ams-hdd001-50010"}), .001);
+    }
+
+    @Test
+    public void testDefaultExportLowercaseOutputName() throws ParseException {
+      JmxCollector jc = new JmxCollector("{`lowercaseOutputName`: true}".replace('`', '"')).register(registry);
+      assertNotNull(registry.getSampleValue("java_lang_operatingsystem_processcputime", new String[]{}, new String[]{}));
     }
 }
 


### PR DESCRIPTION
Lowercaseing labels avoids mixing camelcase with the more common snake case in Prometheus.
Do a straight lowercase, as converting to snakecase would produce confusing names in most cases.

Allowing empty labels makes it easier to combine rules where some attributes may not be present in some cases.