### PR TITLE
Add options for full JMX URL, Username and Password

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,13 @@ java -javaagent:target/jmx_prometheus_javaagent-0.3-SNAPSHOT.jar=1234:config.jso
 
 ## Configuration
 The configuration is in JSON. An example with all possible options:
+
 ```
 { 
   "hostPort": "127.0.0.1:1234",
+  "hostUrl": "service:jmx:rmi:///jndi/rmi://hostname:port/jmxrmi"
+  "username" : "admin"
+  "password" : "admin"
   "lowercaseOutputName": false,
   "lowercaseOutputLabelNames": false,
   "rules": [
@@ -35,9 +39,13 @@ The configuration is in JSON. An example with all possible options:
   ]
 }
 ```
+
 Name     | Description
 ---------|------------
 hostPort | The host and port to connect to via remote JMX. If not specified, will talk to the local JVM.
+hostUrl | The full JMX URL.  If not specified, will use hostPort.
+username | The JMX Connection username.  If not specified, no username/password is used.
+password | The JMX Connection password.  If not specified, no username/passowrd is used.
 lowercaseOutputName | Lowercase the output metric name. Applies to default format and `name`. Defaults to false.
 lowercaseOutputLabelNames | Lowercase the output metric label names. Applies to default format and `labels`. Defaults to false.
 rules    | A list of rules to apply in order, processing stops at the first matching rule. Attributes that aren't matched aren't collected. If not specified, defaults to collecting everything in the default format.
@@ -58,6 +66,7 @@ Example configurations for javaagents can be found at  https://github.com/promet
 
 ### Pattern input
 The format of the input matches against the pattern is
+
 ```
 domain<beanpropertyName1=beanPropertyValue1, beanpropertyName2=beanPropertyValue2, ...><key1, key2, ...>attrName: value
 ```
@@ -75,6 +84,7 @@ The default help includes this string, except for the value.
 
 ### Default format
 The default format will transform beans in a way that should produce sane metrics in most cases. It is
+
 ```
 domain_beanPropertyValue1_key1_key2_...keyN_attrName{beanpropertyName2="beanPropertyValue2", ...}: value
 ```

--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -15,10 +15,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.management.MBeanAttributeInfo;
-import javax.management.MBeanInfo;
-import javax.management.MBeanServerConnection;
-import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -40,6 +37,8 @@ public class JmxCollector extends Collector {
     }
 
     String hostPort;
+    String hostUrl;
+    Map<String,Object> env;
     boolean lowercaseOutputName;
     boolean lowercaseOutputLabelNames;
     ArrayList<Rule> rules = new ArrayList<Rule>();
@@ -57,6 +56,26 @@ public class JmxCollector extends Collector {
         } else {
           // Default to local JVM.
           hostPort = "";
+        }
+
+        if(config.containsKey("hostUrl")) {
+          hostUrl = (String)config.get("hostUrl");
+        } else {
+          //Use hostPort variable if it's set.
+          if(!hostPort.isEmpty()) {
+              hostUrl = "service:jmx:rmi:///jndi/rmi://" + hostPort + "/jmxrmi";
+          } else {
+              hostUrl = "";
+          }
+        }
+
+        if(config.containsKey("username") && config.containsKey("password")) {
+            //Put credentials in if both username & password is defined.
+            env = new HashMap<String,Object>();
+            env.put(JMXConnector.CREDENTIALS, new String[]{(String)config.get("username"), (String)config.get("password")});
+        } else {
+            //Otherwise just set it to null
+            env = null;
         }
 
         if (config.containsKey("lowercaseOutputName")) {
@@ -257,14 +276,14 @@ public class JmxCollector extends Collector {
 
     public List<MetricFamilySamples> collect() {
       Receiver receiver = new Receiver();
-      JmxScraper scraper = new JmxScraper(hostPort, receiver);
+      JmxScraper scraper = new JmxScraper(hostUrl, env, receiver);
       long start = System.nanoTime();
       double error = 0;
       try {
         scraper.doScrape();
       } catch (Exception e) {
         error = 1;
-        LOGGER.severe("JMX scrape failed: " + e);
+        LOGGER.log(Level.SEVERE, "JMX scrape failed: ", e);
       }
       List<MetricFamilySamples> mfsList = new ArrayList<MetricFamilySamples>();
       mfsList.addAll(receiver.metricFamilySamplesMap.values());

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -1,11 +1,7 @@
 package io.prometheus.jmx;
 
 import java.lang.management.ManagementFactory;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.management.MBeanAttributeInfo;
@@ -35,11 +31,19 @@ public class JmxScraper {
     }
 
     private MBeanReceiver receiver;
-    private String hostPort;
+    private String hostUrl;
+    private Map<String,?> env;
 
-    public JmxScraper(String hostPort, MBeanReceiver receiver) {
-        this.hostPort = hostPort;
+    public JmxScraper(String hostUrl, MBeanReceiver receiver) {
+        this.hostUrl = hostUrl;
         this.receiver = receiver;
+        this.env = null;
+    }
+
+    public JmxScraper(String hostUrl,  Map<String,?> env, MBeanReceiver receiver) {
+        this.hostUrl = hostUrl;
+        this.receiver = receiver;
+        this.env = env;
     }
 
     /**
@@ -50,11 +54,12 @@ public class JmxScraper {
     public void doScrape() throws Exception {
         MBeanServerConnection beanConn;
         JMXConnector jmxc = null;
-        if (hostPort.isEmpty()) {
+        if (hostUrl.isEmpty()) {
           beanConn = ManagementFactory.getPlatformMBeanServer();
         } else {
-          String url = "service:jmx:rmi:///jndi/rmi://" + hostPort + "/jmxrmi";
-          jmxc = JMXConnectorFactory.connect(new JMXServiceURL(url), null);
+          //Accepts either the full URL or just host:port
+          String url = hostUrl.contains("/") ? hostUrl : "service:jmx:rmi:///jndi/rmi://" + hostUrl + "/jmxrmi";
+          jmxc = JMXConnectorFactory.connect(new JMXServiceURL(url), env);
           beanConn = jmxc.getMBeanServerConnection();
         }
         try {


### PR DESCRIPTION
This pull request includes a few more optional configuration items to be able to properly set the JMX connection URL and also specify a username & password.  This should be compatible with existing configurations, and if anyone is using the `JmxScraper` class directly, this should also work in the exact same way.

The 3 new options are:
  * **hostUrl**: specify the full JMX URL.  If this isn't defined, it'll create this from hostPort, or set it to nothing if that's not defined (current behaviour).
  * **username**: specify the username when connecting to JMX  Both username and password have to be set for this to be used.
  * **password**: specify the password when connecting to JMX.  Both username and password have to be set for this to be used.

`JmxScraper` has a new overloaded constructor for the `env` variable, which defaults to `null` if username or password is not set (current behaviour).

We also check to see whether hostUrl is in `host:port` form or full URL form by checking for the presence of a`/` character, which is not a valid character for either the hostname or the port number.

The net effect of this change is if you're using either of these classes, their behaviour should not change, unless you're using the 3 above options.

Also added the full stack trace to the logger, which prints out a bit more useful information.
