### PR TITLE
Change output filename on java agent to prevent double shading of the jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See `./run_sample_httpserver.sh` for a sample script that runs the httpserver ag
 To run as a javaagent:
 
 ```
-java -javaagent:target/jmx_prometheus_javaagent-0.3-SNAPSHOT.jar=1234:config.json -jar yourJar.jar
+java -javaagent:target/jmx_prometheus_javaagent-0.3-SNAPSHOT-jar-with-dependencies.jar=1234:config.json -jar yourJar.jar
 ```
 
 ## Configuration

--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -64,6 +64,7 @@
           <goal>shade</goal>
         </goals>
         <configuration>
+          <outputFile>${project.build.directory}/${project.build.finalName}-jar-with-dependencies.jar</outputFile>
           <minimizeJar>true</minimizeJar>
           <relocations>
             <relocation>


### PR DESCRIPTION
This is a strange one and I'm not sure whether it's my version of maven.

If you've already run `mvn package` at least once, then subsequent `mvn package` commands without `clean` causes the Maven Shade plugin to use the combined jar file, rather than the original.
I.e, It doubles up the shading in the jar which causes some weird issues.  For instance, running on tomcat, I get this error message with the bad jar:

```
Exception in thread "main" java.lang.ClassNotFoundException: io.prometheus.jmx.shaded.io.prometheus.jmx.JavaAgent
```

`mvn clean package` works fine.

This fix also changes the output file to be more in-line with the http server project.