### PR TITLE
use daemon threads for jetty

### DIFF
--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -7,6 +7,7 @@ import java.io.FileReader;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 public class JavaAgent {
    static Server server;
@@ -22,6 +23,9 @@ public class JavaAgent {
 
      int port = Integer.parseInt(args[0]);
      server = new Server(port);
+     QueuedThreadPool pool = new QueuedThreadPool();
+     pool.setDaemon(true);
+     server.setThreadPool(pool);
      ServletContextHandler context = new ServletContextHandler();
      context.setContextPath("/");
      server.setHandler(context);


### PR DESCRIPTION
This makes sure Jetty uses daemon threads for clean exit when the JVM stops. It prevents Cassandra hanging on startup when using the agent with the standard Cassandra start scripts. For more background see https://issues.apache.org/jira/browse/CASSANDRA-7254

Before this PR running "java -javaagent:jmx_prometheus_javaagent-0.3-SNAPSHOT.jar=7070:jmx_exporter.json" results in the JVM showing usage text and then not exiting properly. After PR it exits cleanly. (and this is exactly what the cassandra start scripts do)