### PR TITLE
Workaround lack of ordering in JSONObject.

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -88,7 +89,7 @@ public class JmxCollector extends Collector {
               rule.help = (String)jsonRule.get("help");
             }
             if (jsonRule.containsKey("labels")) {
-              JSONObject labels = (JSONObject)jsonRule.get("labels");
+              TreeMap labels = new TreeMap((JSONObject)jsonRule.get("labels"));
               rule.labelNames = new ArrayList<String>();
               rule.labelValues = new ArrayList<String>();
               for (Map.Entry<String, Object> entry : (Set<Map.Entry<String, Object>>)labels.entrySet()) {

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -155,6 +155,6 @@ public class JmxCollectorTest {
     public void testServletRequestPattern() throws ParseException {
       JmxCollector jc = new JmxCollector(
           "{`rules`: [{`pattern`: `Catalina<j2eeType=Servlet, WebModule=//([-a-zA-Z0-9+&@#/%?=~_|!:.,;]*[-a-zA-Z0-9+&@#/%=~_|]), name=([-a-zA-Z0-9+/$%~_-|!.]*), J2EEApplication=none, J2EEServer=none><>RequestCount:`,`name`: `tomcat_request_servlet_count`,`labels`: {`module`:`$1`,`servlet`:`$2` },`help`: `Tomcat servlet request count`,`type`: `COUNTER`,`attrNameSnakeCase`: false}]}".replace('`', '"')).register(registry);
-      assertEquals(1.0, registry.getSampleValue("tomcat_request_servlet_count", new String[]{"servlet","module"}, new String[]{"HTMLHostManager","localhost/host-manager", }), .001);
+      assertEquals(1.0, registry.getSampleValue("tomcat_request_servlet_count", new String[]{"module", "servlet"}, new String[]{"localhost/host-manager", "HTMLHostManager"}), .001);
     }
 }


### PR DESCRIPTION
CollectorRegistry.getSampleValue assumes that the labelNames ordering
matches that of what was provided in the sample. While this is generally
workable, it's not true when it's coming from an unordered JSON map.
See https://github.com/prometheus/client_java/issues/71

Workaround this by sorting the labels we get.