### PR TITLE
Handle UnsupportedOperation and ReflectionExceptions during bean scraping

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -101,6 +101,12 @@ public class JmxScraper {
             } catch(java.rmi.UnmarshalException e) {
                 logScrape(mbeanName, attr, "Fail: " + e);
                 continue;
+            } catch(java.lang.UnsupportedOperationException e) {
+            	logScrape(mbeanName, attr, "Fail: " + e);
+            	continue;
+            } catch(javax.management.ReflectionException e) {
+            	logScrape(mbeanName, attr, "Fail: " + e);
+            	continue;
             }
 
             logScrape(mbeanName, attr, "process");


### PR DESCRIPTION
These changes are necessary to allow the exporter to work with Caucho Resin, and with them allow useful data to retrieved.