### PR TITLE
Fix compiler error: trying to instantiate a Map directly

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -52,7 +52,7 @@ public class JmxCollector extends Collector {
     }
     private JmxCollector(Map<String, Object> config) throws MalformedObjectNameException {
         if(config == null) {  //Yaml config empty, set config to empty map.
-            config = new Map<String, Object>(); 
+            config = new HashMap<String, Object>();
         }
 
         if (config.containsKey("hostPort")) {


### PR DESCRIPTION
Currently the code does not compile, because a Map cannot be instantiated.