### PR TITLE
Cannot connect when using credentials

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -70,10 +70,8 @@ public class JmxScraper {
           HashMap credential = null;
           if(username != null && username.length() != 0 && password != null && password.length() != 0) {
             credential = new HashMap();
-            List<String> credent = new ArrayList<String>();
-            credent.add(username);
-            credent.add(password);
-            credential.put("javax.management.remote.JMXConnector.CREDENTIALS", credent);
+            String[] credent = new String[] {username, password};
+            credential.put(javax.management.remote.JMXConnector.CREDENTIALS, credent);
           }       
 
           jmxc = JMXConnectorFactory.connect(new JMXServiceURL(url), credential);


### PR DESCRIPTION
It's not currently possible to connect to servers that use credentials, because the credentials are configured incorrectly:

The key for credentials is not `"javax.management.remote.JMXConnector.CREDENTIALS"`, but `javax.management.remote.JMXConnector.CREDENTIALS` (which is in fact equal to `"jmx.remote.credentials"`).

Also, credentials must be passed in as an array, rather than as a list.

The attached pull request rectifies these issues.