### PR TITLE
use logger and remove unused local variables

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -350,7 +350,7 @@ public class JmxCollector extends Collector {
       + "`hostPort`: `" + hostPort + "`,"
       + "}").replace('`', '"'));
       for(MetricFamilySamples mfs : jc.collect()) {
-        System.out.println(mfs);
+          LOGGER.info(mfs != null? mfs.toString() : null);
       }
     }
 }

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -289,7 +289,7 @@ public class JmxScraper {
             String attrType,
             String attrDescription,
             Object value) {
-            System.out.println(domain +
+            logger.info(domain +
                                beanProperties + 
                                attrKeys +
                                attrName +

--- a/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
+++ b/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
@@ -2,17 +2,20 @@ package io.prometheus.jmx;
 
 import io.prometheus.client.exporter.MetricsServlet;
 import java.io.FileReader;
+import java.util.logging.Logger;
+
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
 public class WebServer {
+   private static final Logger logger = Logger.getLogger(WebServer.class.getName());
+   
    public static void main(String[] args) throws Exception {
      if (args.length < 2) {
-       System.err.println("Usage: WebServer <port> <yaml configuration file>");
+       logger.severe("Usage: WebServer <port> <yaml configuration file>");
        System.exit(1);
      }
-     JmxCollector jc = new JmxCollector(new FileReader(args[1])).register();
 
      int port = Integer.parseInt(args[0]);
      Server server = new Server(port);

--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -4,18 +4,21 @@ import io.prometheus.client.exporter.MetricsServlet;
 import io.prometheus.client.hotspot.DefaultExports;
 import java.lang.instrument.Instrumentation;
 import java.io.FileReader;
+import java.util.logging.Logger;
+
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 public class JavaAgent {
+   private static final Logger logger = Logger.getLogger(JavaAgent.class.getName());
    static Server server;
 
    public static void premain(String agentArgument, Instrumentation instrumentation) throws Exception {
      String[] args = agentArgument.split(":");
      if (args.length != 2) {
-       System.err.println("Usage: -javaagent:/path/to/JavaAgent.jar=<port>:<yaml configuration file>");
+       logger.severe("Usage: -javaagent:/path/to/JavaAgent.jar=<port>:<yaml configuration file>");
        System.exit(1);
      }
      new JmxCollector(new FileReader(args[1])).register();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S106 - “Standard outputs should not be used directly to log anything”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S106
And
squid:S1481 - “Unused local variables should be removed ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1481
Please let me know if you have any questions.
Ayman Abdelghany.