### PR TITLE
Add label to jmx_scrape_duration_seconds and jmx_scrape_error so that…

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -6,6 +6,7 @@ import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;

--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -328,12 +328,12 @@ public class JmxCollector extends Collector {
       mfsList.addAll(receiver.metricFamilySamplesMap.values());
       List<MetricFamilySamples.Sample> samples = new ArrayList<MetricFamilySamples.Sample>();
       samples.add(new MetricFamilySamples.Sample(
-          "jmx_scrape_duration_seconds", new ArrayList<String>(), new ArrayList<String>(), (System.nanoTime() - start) / 1.0E9));
+          "jmx_scrape_duration_seconds", Arrays.asList("hostPort"), Arrays.asList(hostPort), (System.nanoTime() - start) / 1.0E9));
       mfsList.add(new MetricFamilySamples("jmx_scrape_duration_seconds", Type.GAUGE, "Time this JMX scrape took, in seconds.", samples));
 
       samples = new ArrayList<MetricFamilySamples.Sample>();
       samples.add(new MetricFamilySamples.Sample(
-          "jmx_scrape_error", new ArrayList<String>(), new ArrayList<String>(), error));
+          "jmx_scrape_error", Arrays.asList("hostPort"), Arrays.asList(hostPort), error));
       mfsList.add(new MetricFamilySamples("jmx_scrape_error", Type.GAUGE, "Non-zero if this scrape failed.", samples));
       return mfsList;
     }


### PR DESCRIPTION
… multiple hosts can be exported by one JMX exporter.