### PR TITLE
Use Java collection interfaces and add private constructor

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -33,8 +33,8 @@ public class JmxCollector extends Collector {
       String help;
       boolean attrNameSnakeCase;
       Type type = Type.GAUGE;
-      ArrayList<String> labelNames;
-      ArrayList<String> labelValues;
+      List<String> labelNames;
+      List<String> labelValues;
     }
 
     String jmxUrl;
@@ -45,7 +45,7 @@ public class JmxCollector extends Collector {
     boolean lowercaseOutputLabelNames;
     List<ObjectName> whitelistObjectNames = new ArrayList<ObjectName>();
     List<ObjectName> blacklistObjectNames = new ArrayList<ObjectName>();
-    ArrayList<Rule> rules = new ArrayList<Rule>();
+    List<Rule> rules = new ArrayList<Rule>();
 
     private static final Pattern snakeCasePattern = Pattern.compile("([a-z0-9])([A-Z])");
 
@@ -186,8 +186,8 @@ public class JmxCollector extends Collector {
 
       private void defaultExport(
           String domain,
-          LinkedHashMap<String, String> beanProperties,
-          LinkedList<String> attrKeys,
+          Map<String, String> beanProperties,
+          List<String> attrKeys,
           String attrName,
           String attrType,
           String help,
@@ -233,8 +233,8 @@ public class JmxCollector extends Collector {
 
       public void recordBean(
           String domain,
-          LinkedHashMap<String, String> beanProperties,
-          LinkedList<String> attrKeys,
+          Map<String, String> beanProperties,
+          List<String> attrKeys,
           String attrName,
           String attrType,
           String attrDescription,

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.logging.Level;
@@ -50,8 +51,8 @@ public class JmxScraper {
     public static interface MBeanReceiver {
         void recordBean(
             String domain,
-            LinkedHashMap<String, String> beanProperties,
-            LinkedList<String> attrKeys,
+            Map<String, String> beanProperties,
+            List<String> attrKeys,
             String attrName,
             String attrType,
             String attrDescription,
@@ -84,7 +85,7 @@ public class JmxScraper {
         if (jmxUrl.isEmpty()) {
           beanConn = ManagementFactory.getPlatformMBeanServer();
         } else {
-          HashMap credential = null;
+          Map credential = null;
           if(username != null && username.length() != 0 && password != null && password.length() != 0) {
             credential = new HashMap();
             String[] credent = new String[] {username, password};
@@ -283,8 +284,8 @@ public class JmxScraper {
     private static class StdoutWriter implements MBeanReceiver {
         public void recordBean(
             String domain,
-            LinkedHashMap<String, String> beanProperties,
-            LinkedList<String> attrKeys,
+            Map<String, String> beanProperties,
+            List<String> attrKeys,
             String attrName,
             String attrType,
             String attrDescription,

--- a/collector/src/test/java/io/prometheus/jmx/GetKeyPropertyListTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/GetKeyPropertyListTest.java
@@ -11,55 +11,55 @@ public class GetKeyPropertyListTest {
 
     @Test
     public void testSingleObjectName() throws Throwable {
-        LinkedHashMap<String, String> parameterList = JmxScraper.getKeyPropertyList(new ObjectName("com.organisation:name=value"));
+        Map<String, String> parameterList = JmxScraper.getKeyPropertyList(new ObjectName("com.organisation:name=value"));
         assertSameElementsAndOrder(parameterList, "name", "value");
     }
 
     @Test
     public void testSimpleObjectName() throws Throwable {
-        LinkedHashMap<String, String> parameterList = JmxScraper.getKeyPropertyList(new ObjectName("com.organisation:name=value,name2=value2"));
+        Map<String, String> parameterList = JmxScraper.getKeyPropertyList(new ObjectName("com.organisation:name=value,name2=value2"));
         assertSameElementsAndOrder(parameterList, "name", "value", "name2", "value2");
     }
 
     @Test
     public void testQuotedObjectName() throws Throwable {
-        LinkedHashMap<String, String> parameterList = JmxScraper.getKeyPropertyList(new ObjectName("com.organisation:name=value,name2=\"value2\""));
+        Map<String, String> parameterList = JmxScraper.getKeyPropertyList(new ObjectName("com.organisation:name=value,name2=\"value2\""));
         assertSameElementsAndOrder(parameterList, "name", "value", "name2", "\"value2\"");
     }
 
     @Test
     public void testQuotedObjectNameWithComma() throws Throwable {
-        LinkedHashMap<String, String> parameterList = JmxScraper.getKeyPropertyList(new ObjectName("com.organisation:name=\"value,more\",name2=value2"));
+        Map<String, String> parameterList = JmxScraper.getKeyPropertyList(new ObjectName("com.organisation:name=\"value,more\",name2=value2"));
         assertSameElementsAndOrder(parameterList, "name", "\"value,more\"", "name2", "value2");
     }
 
     @Test
     public void testQuotedObjectNameWithEquals() throws Throwable {
-        LinkedHashMap<String, String> parameterList = JmxScraper.getKeyPropertyList(new ObjectName("com.organisation:name=\"value=more\",name2=value2"));
+        Map<String, String> parameterList = JmxScraper.getKeyPropertyList(new ObjectName("com.organisation:name=\"value=more\",name2=value2"));
         assertSameElementsAndOrder(parameterList, "name", "\"value=more\"", "name2", "value2");
     }
 
     @Test
     public void testQuotedObjectNameWithQuote() throws Throwable {
-        LinkedHashMap<String, String> parameterList = JmxScraper.getKeyPropertyList(new ObjectName("com.organisation:name=\"value\\\"more\",name2=value2"));
+        Map<String, String> parameterList = JmxScraper.getKeyPropertyList(new ObjectName("com.organisation:name=\"value\\\"more\",name2=value2"));
         assertSameElementsAndOrder(parameterList, "name", "\"value\\\"more\"", "name2", "value2");
     }
 
     @Test
     public void testQuotedObjectNameWithBackslash() throws Throwable {
-        LinkedHashMap<String, String> parameterList = JmxScraper.getKeyPropertyList(new ObjectName("com.organisation:name=\"value\\\\more\",name2=value2"));
+        Map<String, String> parameterList = JmxScraper.getKeyPropertyList(new ObjectName("com.organisation:name=\"value\\\\more\",name2=value2"));
         assertSameElementsAndOrder(parameterList, "name", "\"value\\\\more\"", "name2", "value2");
     }
 
     @Test
     public void testQuotedObjectNameWithMultipleQuoted() throws Throwable {
-        LinkedHashMap<String, String> parameterList = JmxScraper.getKeyPropertyList(new ObjectName("com.organisation:name=\"value\\\\\\?\\*\\n\\\",:=more\",name2= value2 "));
+        Map<String, String> parameterList = JmxScraper.getKeyPropertyList(new ObjectName("com.organisation:name=\"value\\\\\\?\\*\\n\\\",:=more\",name2= value2 "));
         assertSameElementsAndOrder(parameterList, "name", "\"value\\\\\\?\\*\\n\\\",:=more\"", "name2", " value2 ");
     }
 
     @Test
     public void testIssue52() throws Throwable {
-        LinkedHashMap<String, String> parameterList = JmxScraper.getKeyPropertyList(
+        Map<String, String> parameterList = JmxScraper.getKeyPropertyList(
                 new ObjectName("org.apache.camel:context=ourinternalname,type=endpoints,name=\"seda://endpointName\\?concurrentConsumers=8&size=50000\""));
         assertSameElementsAndOrder(parameterList,
                 "context", "ourinternalname",
@@ -67,7 +67,7 @@ public class GetKeyPropertyListTest {
                 "name", "\"seda://endpointName\\?concurrentConsumers=8&size=50000\"");
     }
 
-    private void assertSameElementsAndOrder(LinkedHashMap<?, ?> actual, Object... expected) {
+    private void assertSameElementsAndOrder(Map<?, ?> actual, Object... expected) {
         assert expected.length % 2 == 0;
         List<Map.Entry<?,?>> actualList = new ArrayList<Map.Entry<?, ?>>(actual.entrySet());
         List<Map.Entry<?,?>> expectedList = new ArrayList<Map.Entry<?,?>>();

--- a/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
+++ b/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
@@ -7,6 +7,11 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
 public class WebServer {
+
+   private WebServer() {
+     throw new UnsupportedOperationException();     
+   }
+   
    public static void main(String[] args) throws Exception {
      if (args.length < 2) {
        System.err.println("Usage: WebServer <port> <yaml configuration file>");

--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -12,6 +12,10 @@ import org.eclipse.jetty.util.thread.QueuedThreadPool;
 public class JavaAgent {
    static Server server;
 
+   private JavaAgent() {
+     throw new UnsupportedOperationException();
+   }
+
    public static void premain(String agentArgument, Instrumentation instrumentation) throws Exception {
      String[] args = agentArgument.split(":");
      if (args.length != 2) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1319 - “ Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1319
And
squid:S1118 - “ Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.