### PR TITLE
health endpoint

### DIFF
--- a/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/HealthServlet.java
+++ b/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/HealthServlet.java
@@ -1,0 +1,30 @@
+package io.prometheus.jmx;
+
+import io.prometheus.client.exporter.common.TextFormat;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Writer;
+
+public class HealthServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        resp.setStatus(HttpServletResponse.SC_OK);
+        resp.setContentType(TextFormat.CONTENT_TYPE_004);
+
+        Writer writer = resp.getWriter();
+        writer.write("ok\n");
+        writer.flush();
+        writer.close();
+    }
+
+    @Override
+    protected void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        doGet(req, resp);
+    }
+
+}

--- a/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/HealthServlet.java
+++ b/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/HealthServlet.java
@@ -1,7 +1,5 @@
 package io.prometheus.jmx;
 
-import io.prometheus.client.exporter.common.TextFormat;
-
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -14,7 +12,7 @@ public class HealthServlet extends HttpServlet {
     @Override
     protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
         resp.setStatus(HttpServletResponse.SC_OK);
-        resp.setContentType(TextFormat.CONTENT_TYPE_004);
+        resp.setContentType("text/plain");
 
         Writer writer = resp.getWriter();
         writer.write("ok\n");

--- a/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
+++ b/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
@@ -20,6 +20,7 @@ public class WebServer {
      context.setContextPath("/");
      server.setHandler(context);
      context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
+     context.addServlet(new ServletHolder(new HealthServlet()),  "/health");
      server.start();
      server.join();
    }


### PR DESCRIPTION
just health endpoint to check that jmx_exporter is working.
because jmx_exporter now has no cache, it's heavy to use /metrics for this.