### PR TITLE
Allow jmx agent to communicate with a secure registry over SSL

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -31,8 +31,7 @@ import javax.management.remote.rmi.RMIConnectorServer;
 
 
 public class JmxScraper {
-    private static final Logger logger = Logger.getLogger(JmxScraper.class.getName());
-
+    private static final Logger logger = Logger.getLogger(JmxScraper.class.getName());;
     private static final Pattern PROPERTY_PATTERN = Pattern.compile(
             "([^,=:\\*\\?]+)" + // Name - non-empty, anything but comma, equals, colon, star, or question mark
                     "=" +  // Equals
@@ -79,7 +78,7 @@ public class JmxScraper {
 
     /**
      * Get a list of mbeans on host_port and scrape their values.
-     * <p>
+     *
      * Values are passed to the receiver in a single thread.
      */
     public void doScrape() throws Exception {
@@ -89,8 +88,8 @@ public class JmxScraper {
             beanConn = ManagementFactory.getPlatformMBeanServer();
         } else {
             HashMap<String, Object> env = new HashMap<String, Object>();
-            if (username != null && username.length() != 0 && password != null && password.length() != 0) {
-                String[] credent = new String[]{username, password};
+            if(username != null && username.length() != 0 && password != null && password.length() != 0) {
+                String[] credent = new String[] {username, password};
                 env.put(javax.management.remote.JMXConnector.CREDENTIALS, credent);
             }
 
@@ -143,7 +142,7 @@ public class JmxScraper {
             Object value;
             try {
                 value = beanConn.getAttribute(mbeanName, attr.getName());
-            } catch (Exception e) {
+            } catch(Exception e) {
                 logScrape(mbeanName, attr, "Fail: " + e);
                 continue;
             }
@@ -211,7 +210,7 @@ public class JmxScraper {
             CompositeType type = composite.getCompositeType();
             attrKeys = new LinkedList<String>(attrKeys);
             attrKeys.add(attrName);
-            for (String key : type.keySet()) {
+            for(String key : type.keySet()) {
                 String typ = type.getType(key).getTypeName();
                 Object valu = composite.get(key);
                 processBeanValue(
@@ -248,7 +247,7 @@ public class JmxScraper {
                     for (String idx : rowKeys) {
                         l2s.put(idx, composite.get(idx).toString());
                     }
-                    for (String valueIdx : valueKeys) {
+                    for(String valueIdx : valueKeys) {
                         LinkedList<String> attrNames = extendedAttrKeys;
                         String typ = type.getType(valueIdx).getTypeName();
                         String name = valueIdx;
@@ -283,7 +282,6 @@ public class JmxScraper {
     private static void logScrape(ObjectName mbeanName, MBeanAttributeInfo attr, String msg) {
         logScrape(mbeanName + "'_'" + attr.getName(), msg);
     }
-
     private static void logScrape(String name, String msg) {
         logger.log(Level.FINE, "scrape: '" + name + "': " + msg);
     }
@@ -311,13 +309,14 @@ public class JmxScraper {
     public static void main(String[] args) throws Exception {
         List<ObjectName> objectNames = new LinkedList<ObjectName>();
         objectNames.add(null);
-        if (args.length > 0) {
+        if (args.length > 0){
             new JmxScraper(args[0], "", "", objectNames, new LinkedList<ObjectName>(), new StdoutWriter()).doScrape();
-        } else if (args.length >= 3) {
+        }
+        else if (args.length >= 3){
             new JmxScraper(args[0], args[1], args[2], objectNames, new LinkedList<ObjectName>(), new StdoutWriter()).doScrape();
-        } else {
+        }
+        else {
             new JmxScraper("", "", "", objectNames, new LinkedList<ObjectName>(), new StdoutWriter()).doScrape();
         }
     }
 }
-

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -32,7 +32,7 @@ import javax.management.remote.rmi.RMIConnectorServer;
 
 public class JmxScraper {
     private static final Logger logger = Logger.getLogger(JmxScraper.class.getName());
-    
+
     private static final Pattern PROPERTY_PATTERN = Pattern.compile(
             "([^,=:\\*\\?]+)" + // Name - non-empty, anything but comma, equals, colon, star, or question mark
                     "=" +  // Equals

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -31,12 +31,12 @@ import javax.management.remote.rmi.RMIConnectorServer;
 
 
 public class JmxScraper {
-    private static final Logger logger = Logger.getLogger(JmxScraper.class.getName());
+    private static final Logger logger = Logger.getLogger(JmxScraper.class.getName());;
     private static final Pattern PROPERTY_PATTERN = Pattern.compile(
             "([^,=:\\*\\?]+)" + // Name - non-empty, anything but comma, equals, colon, star, or question mark
-                    "=" +  // Equals
-                    "(" + // Either
-                    "\"" + // Quoted
+            "=" +  // Equals
+            "(" + // Either
+                "\"" + // Quoted
                     "(?:" + // A possibly empty sequence of
                     "[^\\\\\"]" + // Anything but backslash or quote
                     "|\\\\\\\\" + // or an escaped backslash
@@ -45,20 +45,20 @@ public class JmxScraper {
                     "|\\\\\\?" + // or an escaped question mark
                     "|\\\\\\*" + // or an escaped star
                     ")*" +
-                    "\"" +
-                    "|" + // Or
-                    "[^,=:\"]*" + // Unquoted - can be empty, anything but comma, equals, colon, or quote
-                    ")");
+                "\"" +
+            "|" + // Or
+                "[^,=:\"]*" + // Unquoted - can be empty, anything but comma, equals, colon, or quote
+            ")");
 
     public static interface MBeanReceiver {
         void recordBean(
-                String domain,
-                LinkedHashMap<String, String> beanProperties,
-                LinkedList<String> attrKeys,
-                String attrName,
-                String attrType,
-                String attrDescription,
-                Object value);
+            String domain,
+            LinkedHashMap<String, String> beanProperties,
+            LinkedList<String> attrKeys,
+            String attrName,
+            String attrType,
+            String attrDescription,
+            Object value);
     }
 
     private MBeanReceiver receiver;
@@ -77,28 +77,28 @@ public class JmxScraper {
     }
 
     /**
-     * Get a list of mbeans on host_port and scrape their values.
-     *
-     * Values are passed to the receiver in a single thread.
-     */
+      * Get a list of mbeans on host_port and scrape their values.
+      *
+      * Values are passed to the receiver in a single thread.
+      */
     public void doScrape() throws Exception {
         MBeanServerConnection beanConn;
         JMXConnector jmxc = null;
         if (jmxUrl.isEmpty()) {
-            beanConn = ManagementFactory.getPlatformMBeanServer();
+          beanConn = ManagementFactory.getPlatformMBeanServer();
         } else {
-            HashMap<String, Object> env = new HashMap<String, Object>();
-            if(username != null && username.length() != 0 && password != null && password.length() != 0) {
-                String[] credent = new String[] {username, password};
-                env.put(javax.management.remote.JMXConnector.CREDENTIALS, credent);
-            }
+          HashMap<String, Object> env = new HashMap<String, Object>();
+          if(username != null && username.length() != 0 && password != null && password.length() != 0) {
+            String[] credent = new String[] {username, password};
+            env.put(javax.management.remote.JMXConnector.CREDENTIALS, credent);
+          }       
 
-            SslRMIClientSocketFactory clientSocketFactory = new SslRMIClientSocketFactory();
-            env.put(Context.SECURITY_PROTOCOL, "ssl");
-            env.put(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE, clientSocketFactory);
-            env.put("com.sun.jndi.rmi.factory.socket", clientSocketFactory);
-            jmxc = JMXConnectorFactory.connect(new JMXServiceURL(jmxUrl), env);
-            beanConn = jmxc.getMBeanServerConnection();
+          SslRMIClientSocketFactory clientSocketFactory = new SslRMIClientSocketFactory();
+          env.put(Context.SECURITY_PROTOCOL, "ssl");
+          env.put(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE, clientSocketFactory);
+          env.put("com.sun.jndi.rmi.factory.socket", clientSocketFactory);
+          jmxc = JMXConnectorFactory.connect(new JMXServiceURL(jmxUrl), env);
+          beanConn = jmxc.getMBeanServerConnection();
         }
         try {
             // Query MBean names.
@@ -113,22 +113,22 @@ public class JmxScraper {
                 scrapeBean(beanConn, name);
             }
         } finally {
-            if (jmxc != null) {
-                jmxc.close();
-            }
+          if (jmxc != null) {
+            jmxc.close();
+          }
         }
     }
 
     private void scrapeBean(MBeanServerConnection beanConn, ObjectName mbeanName) {
         MBeanInfo info;
         try {
-            info = beanConn.getMBeanInfo(mbeanName);
+          info = beanConn.getMBeanInfo(mbeanName);
         } catch (IOException e) {
-            logScrape(mbeanName.toString(), "getMBeanInfo Fail: " + e);
-            return;
+          logScrape(mbeanName.toString(), "getMBeanInfo Fail: " + e);
+          return;
         } catch (JMException e) {
-            logScrape(mbeanName.toString(), "getMBeanInfo Fail: " + e);
-            return;
+          logScrape(mbeanName.toString(), "getMBeanInfo Fail: " + e);
+          return;
         }
         MBeanAttributeInfo[] attrInfos = info.getAttributes();
 
@@ -156,7 +156,7 @@ public class JmxScraper {
                     attr.getType(),
                     attr.getDescription(),
                     value
-            );
+                    );
         }
     }
 
@@ -255,15 +255,15 @@ public class JmxScraper {
                             // Skip appending 'value' to the name
                             attrNames = attrKeys;
                             name = attrName;
-                        }
+                        } 
                         processBeanValue(
-                                domain,
-                                l2s,
-                                attrNames,
-                                name,
-                                typ,
-                                type.getDescription(),
-                                composite.get(valueIdx));
+                            domain,
+                            l2s,
+                            attrNames,
+                            name,
+                            typ,
+                            type.getDescription(),
+                            composite.get(valueIdx));
                     }
                 } else {
                     logScrape(domain, "not a correct tabulardata format");
@@ -288,18 +288,18 @@ public class JmxScraper {
 
     private static class StdoutWriter implements MBeanReceiver {
         public void recordBean(
-                String domain,
-                LinkedHashMap<String, String> beanProperties,
-                LinkedList<String> attrKeys,
-                String attrName,
-                String attrType,
-                String attrDescription,
-                Object value) {
+            String domain,
+            LinkedHashMap<String, String> beanProperties,
+            LinkedList<String> attrKeys,
+            String attrName,
+            String attrType,
+            String attrDescription,
+            Object value) {
             System.out.println(domain +
-                    beanProperties +
-                    attrKeys +
-                    attrName +
-                    ": " + value);
+                               beanProperties + 
+                               attrKeys +
+                               attrName +
+                               ": " + value);
         }
     }
 
@@ -307,16 +307,16 @@ public class JmxScraper {
      * Convenience function to run standalone.
      */
     public static void main(String[] args) throws Exception {
-        List<ObjectName> objectNames = new LinkedList<ObjectName>();
-        objectNames.add(null);
-        if (args.length > 0){
-            new JmxScraper(args[0], "", "", objectNames, new LinkedList<ObjectName>(), new StdoutWriter()).doScrape();
-        }
-        else if (args.length >= 3){
-            new JmxScraper(args[0], args[1], args[2], objectNames, new LinkedList<ObjectName>(), new StdoutWriter()).doScrape();
-        }
-        else {
-            new JmxScraper("", "", "", objectNames, new LinkedList<ObjectName>(), new StdoutWriter()).doScrape();
-        }
+      List<ObjectName> objectNames = new LinkedList<ObjectName>();
+      objectNames.add(null);
+      if (args.length > 0){
+          new JmxScraper(args[0], "", "", objectNames, new LinkedList<ObjectName>(), new StdoutWriter()).doScrape();
+      }
+      else if (args.length >= 3){
+          new JmxScraper(args[0], args[1], args[2], objectNames, new LinkedList<ObjectName>(), new StdoutWriter()).doScrape();
+      }
+      else {
+          new JmxScraper("", "", "", objectNames, new LinkedList<ObjectName>(), new StdoutWriter()).doScrape();
+      }
     }
 }

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -31,7 +31,7 @@ import javax.management.remote.rmi.RMIConnectorServer;
 
 
 public class JmxScraper {
-    private static final Logger logger = Logger.getLogger(JmxScraper.class.getName());;
+    private static final Logger logger = Logger.getLogger(JmxScraper.class.getName());
     private static final Pattern PROPERTY_PATTERN = Pattern.compile(
             "([^,=:\\*\\?]+)" + // Name - non-empty, anything but comma, equals, colon, star, or question mark
                     "=" +  // Equals


### PR DESCRIPTION
When using an encrypted JMX connection for a java process, the JMX agent does not recognize these connections and sees the following error "ConnectIOException: non-JRMP server at remote endpoint" (ultimately a scrape error when you query the /metrics endpoint). 

You can provide a trust store to the JVM when starting the prometheus exporter as an agent, for example: `java -Djavax.net.ssl.trustStore=${/path/to/truststore} -javaagent:${/path/to/prometheus_javaagent/jar} ...` and you'll be able to see the MBeans

In the case of NoSQL, this is the same trust file provided as `oracle.kv.ssl.trustStore` in `client.security`

I've verified the code in this PR works for Oracle NoSQL enterprise and Apache Tomcat.
