### PR TITLE
add read and write counts by column family

### DIFF
--- a/example_configs/cassandra.yml
+++ b/example_configs/cassandra.yml
@@ -12,3 +12,8 @@ rules:
   labels:
     "$1": "$4"
     "$2": "$3"
+- pattern: org.apache.cassandra.db<type=ColumnFamilies, keyspace=(\S*), columnfamily=(\S*)><>(ReadCount|WriteCount)
+  name: cassandra_columnfamily_$3
+  labels:
+    "keyspace": "$1"
+    "columnfamily": "$2"


### PR DESCRIPTION
Read and write counters for individual column families are not included under org.apache.cassandra.metrics.
Added them from org.apache.cassandra.db

@brian-brazil 