### PR TITLE
Set the maximum number of threads and queue size to 10 to avoid app DoS

### DIFF
--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -40,6 +40,9 @@ public class JavaAgent {
      server = new Server(socket);
      QueuedThreadPool pool = new QueuedThreadPool();
      pool.setDaemon(true);
+     pool.setMaxThreads(10);
+     pool.setMaxQueued(10);
+     pool.setName("jmx_exporter");
      server.setThreadPool(pool);
      ServletContextHandler context = new ServletContextHandler();
      context.setContextPath("/");


### PR DESCRIPTION
On a JVM where a scrape goes over Prometheus' scrape_timeout due to high load, Prometheus may hit the target again before the initial thread completes the scrape, contributing to the high load.

The default number of threads QueuedThreadPool will create is 254. Having this much scrapes in parallel cause high memory usage when there are many JMX beans to scrape, potentially tipping the server over its max heap size, and also contributing to CPU load because of full GC.

Setting the max number of threads to 10 provides enough to the server for accepting connections and handling few of them before queuing. This could be configurable, but I don't see any use-case.

I've also set the thread pool name to "jmx_exporter", so we get "jmx_exporter-182" instead of "qtp22756955-182" in thread dumps.