### PR TITLE
Bump max threads to resolve #122

### DIFF
--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -40,7 +40,7 @@ public class JavaAgent {
      server = new Server(socket);
      QueuedThreadPool pool = new QueuedThreadPool();
      pool.setDaemon(true);
-     pool.setMaxThreads(10);
+     pool.setMaxThreads(20);
      pool.setMaxQueued(10);
      pool.setName("jmx_exporter");
      server.setThreadPool(pool);


### PR DESCRIPTION
Resolves #122 for my use case.

I don't fully understand why this works but it does seem to! The bit that confuses me is that the thread limit of 10 seems to kick in when the cores are >20, rather than >10. The server I'm testing this on has 12 cores plus hyper-threading so the OS presents 24 cores, so maybe the HT is creating the x2 difference.

Obviously this isn't a general fix but it works for my use-case so thought I'd contribute in case it's useful