### PR TITLE
Fix order of example rules and add more labels

### DIFF
--- a/example_configs/kafka-0-8-2.yml
+++ b/example_configs/kafka-0-8-2.yml
@@ -22,7 +22,7 @@ rules:
 - pattern : kafka.network<type=(.+), name=(\w+), networkProcessor=(.+)><>Count
   name: kafka_network_$1_$2
   labels:
-    networkProcessor: "$3"
+    request: "$3"
   type: COUNTER
 - pattern : kafka.network<type=(.+), name=(\w+), request=(\w+)><>Count
   name: kafka_network_$1_$2

--- a/example_configs/kafka-0-8-2.yml
+++ b/example_configs/kafka-0-8-2.yml
@@ -33,22 +33,36 @@ rules:
 - pattern : kafka.server<type=(.+), name=(.+)PerSec\w*><>Count
   name: kafka_server_$1_$2_total
   type: COUNTER
-- pattern : kafka.server<type=(.+), name=(.+), topic=(.+)><>(Count|Value)
+
+- pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>(Count|Value)
   name: kafka_server_$1_$2
   labels:
-    topic: "$3"
-  type: COUNTER
+    clientId: "$3"
+    topic: "$4"
+    partition: "$5"
 - pattern : kafka.server<type=(.+), name=(.+), topic=(.+), partition=(.*)><>(Count|Value)
   name: kafka_server_$1_$2
   labels:
     topic: "$3"
     partition: "$4"
-- pattern : kafka.server<type=(.+), name=(.+)><>(Count|Value)
+- pattern : kafka.server<type=(.+), name=(.+), topic=(.+)><>(Count|Value)
   name: kafka_server_$1_$2
+  labels:
+    topic: "$3"
+  type: COUNTER
+
+- pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>(Count|Value)
+  name: kafka_server_$1_$2
+  labels:
+    clientId: "$3"
+    broker: "$4:$5"
 - pattern : kafka.server<type=(.+), name=(.+), clientId=(.+)><>(Count|Value)
   name: kafka_server_$1_$2
   labels:
-    clientId: "$2"
+    clientId: "$3"
+- pattern : kafka.server<type=(.+), name=(.+)><>(Count|Value)
+  name: kafka_server_$1_$2
+
 - pattern : kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count
   name: kafka_$1_$2_$3_total
 - pattern : kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, topic=(.+)><>Count

--- a/example_configs/kafka-0-8-2.yml
+++ b/example_configs/kafka-0-8-2.yml
@@ -22,8 +22,12 @@ rules:
 - pattern : kafka.network<type=(.+), name=(\w+), networkProcessor=(.+)><>Count
   name: kafka_network_$1_$2
   labels:
-    request: "$3"
+    networkProcessor: "$3"
   type: COUNTER
+- pattern : kafka.network<type=(.+), name=(\w+), request=(\w+)><>Count
+  name: kafka_network_$1_$2
+  labels:
+    request: "$3"
 - pattern : kafka.network<type=(.+), name=(\w+)><>Count
   name: kafka_network_$1_$2
 - pattern : kafka.server<type=(.+), name=(.+)PerSec\w*, topic=(.+)><>Count


### PR DESCRIPTION
This fixes the example kafka rules to parse all (on my system) mbeans and move all dynamic fields like brokerhost, port, thread ids etc into labels.

I also reversed the order of two rules, as the first matching pattern wins and the second rule was more concrete.

ping @brian-brazil 