### PR TITLE
Add options to time jmx_call when running in standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,27 @@ If a given part isn't set, it'll be excluded.
 
 `mvn test` to test.
 
+## Debugging
+
+You can start the jmx's scraper in standlone mode in order to debug what is called 
+
+`java -cp jmx_exporter.jar io.prometheus.jmx.JmxScraper  service:jmx:rmi:your_url`
+
+To get finer logs (including the duration of each jmx call),
+create a file called logging.properties with this content:
+
+```
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level=ALL
+io.prometheus.jmx.level=ALL
+io.prometheus.jmx.shaded.io.prometheus.jmx.level=ALL
+```
+
+Add the following flag to your Java invocation:
+
+`-Djava.util.logging.config.file=/path/to/logging.properties`
+
+
 ## Installing
 
 A Debian binary package is created as part of the build process and it can

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -116,7 +116,9 @@ public class JmxScraper {
                 mBeanNames.removeAll(beanConn.queryMBeans(name, null));
             }
             for (ObjectInstance name : mBeanNames) {
+                long start = System.nanoTime();
                 scrapeBean(beanConn, name.getObjectName());
+                logger.fine("TIME: " + (System.nanoTime() - start) + " ns for " + name.getObjectName().toString());
             }
         } finally {
           if (jmxc != null) {


### PR DESCRIPTION
It is often useful when there is a lot of jmx entries available to time them in order to exclude those that take a lot of time (i.e: Cassandra).

This PR add the options --time_jmx_call to do so.

Feel free to comment if it not to your taste.