### PR TITLE
Allow to cache results of scraping and expose metrics true timestamp

### DIFF
--- a/jmx_prometheus_httpserver/pom.xml
+++ b/jmx_prometheus_httpserver/pom.xml
@@ -46,8 +46,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
 

--- a/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/MetricsServletCache.java
+++ b/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/MetricsServletCache.java
@@ -1,0 +1,86 @@
+package io.prometheus.jmx;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Enumeration;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class MetricsServletCache extends HttpServlet {
+
+    public static final int DEFAULT_TTL_IN_SEC = 60 * 1;
+
+    private CollectorRegistry registry;
+    private final StringWriter writerCache;
+    private final int ttl;
+    private AtomicLong lastUpdateTs;
+    private ReentrantReadWriteLock lock;
+
+    /**
+     * Construct a MetricsServletAccess for the default registry.
+     */
+    public MetricsServletCache() {
+        this(CollectorRegistry.defaultRegistry, DEFAULT_TTL_IN_SEC);
+    }
+
+    public MetricsServletCache(int cache_ttl) {
+        this(CollectorRegistry.defaultRegistry, cache_ttl);
+    }
+    /**
+     * Construct a MetricsServletAccess for the given registry.
+     */
+    public MetricsServletCache(CollectorRegistry registry, int ttlInSec) {
+        this.registry = registry;
+        this.writerCache = new StringWriter();
+        this.ttl = ttlInSec * 1000;
+        this.lastUpdateTs = new AtomicLong();
+        this.lock = new ReentrantReadWriteLock();
+    }
+
+    @Override
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
+            throws ServletException, IOException {
+
+        resp.setStatus(HttpServletResponse.SC_OK);
+        resp.setContentType(TextFormat.CONTENT_TYPE_004);
+
+        final long now = System.currentTimeMillis();
+        final long lastUpdate = lastUpdateTs.get();
+        if (lastUpdate + ttl <= now && lastUpdateTs.compareAndSet(lastUpdate, now)) {
+            // Atomic compare and set succeeded, so we will be the only one to update the cache
+            Enumeration<Collector.MetricFamilySamples> samples = registry.metricFamilySamples();
+            lock.writeLock().lock();
+            try {
+                writerCache.getBuffer().setLength(0);
+                TextFormat.write004(writerCache, samples, now);
+                writerCache.flush();
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        lock.readLock().lock();
+        try (Writer writer = resp.getWriter()) {
+            writer.write(writerCache.toString());
+            writer.flush();
+        } finally {
+            lock.readLock().unlock();
+        }
+
+    }
+
+    @Override
+    protected void doPost(final HttpServletRequest req, final HttpServletResponse resp)
+            throws ServletException, IOException {
+        doGet(req, resp);
+    }
+
+}

--- a/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/TextFormat.java
+++ b/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/TextFormat.java
@@ -1,0 +1,104 @@
+package io.prometheus.jmx;
+
+import io.prometheus.client.Collector;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Collections;
+import java.util.Enumeration;
+
+public class TextFormat {
+    /**
+     * Content-type for text version 0.0.4.
+     */
+    public final static String CONTENT_TYPE_004 = "text/plain; version=0.0.4; charset=utf-8";
+
+    /**
+     * Write out the text version 0.0.4 of the given MetricFamilySamples.
+     */
+    public static void write004(Writer writer, Enumeration<Collector.MetricFamilySamples> mfs, long timestamp) throws IOException {
+    /* See http://prometheus.io/docs/instrumenting/exposition_formats/
+     * for the output format specification. */
+        for (Collector.MetricFamilySamples metricFamilySamples: Collections.list(mfs)) {
+            writer.write("# HELP ");
+            writer.write(metricFamilySamples.name);
+            writer.write(' ');
+            writeEscapedHelp(writer, metricFamilySamples.help);
+            writer.write('\n');
+
+            writer.write("# TYPE ");
+            writer.write(metricFamilySamples.name);
+            writer.write(' ');
+            writer.write(typeString(metricFamilySamples.type));
+            writer.write('\n');
+
+            for (Collector.MetricFamilySamples.Sample sample: metricFamilySamples.samples) {
+                writer.write(sample.name);
+                if (sample.labelNames.size() > 0) {
+                    writer.write('{');
+                    for (int i = 0; i < sample.labelNames.size(); ++i) {
+                        writer.write(sample.labelNames.get(i));
+                        writer.write("=\"");
+                        writeEscapedLabelValue(writer, sample.labelValues.get(i));
+                        writer.write("\",");
+                    }
+                    writer.write('}');
+                }
+                writer.write(' ');
+                writer.write(Collector.doubleToGoString(sample.value));
+                writer.write(' ');
+                writer.write("" + timestamp);
+                writer.write('\n');
+            }
+        }
+    }
+
+    private static void writeEscapedHelp(Writer writer, String s) throws IOException {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\':
+                    writer.append("\\\\");
+                    break;
+                case '\n':
+                    writer.append("\\n");
+                    break;
+                default:
+                    writer.append(c);
+            }
+        }
+    }
+
+    private static void writeEscapedLabelValue(Writer writer, String s) throws IOException {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\':
+                    writer.append("\\\\");
+                    break;
+                case '\"':
+                    writer.append("\\\"");
+                    break;
+                case '\n':
+                    writer.append("\\n");
+                    break;
+                default:
+                    writer.append(c);
+            }
+        }
+    }
+
+    private static String typeString(Collector.Type t) {
+        switch (t) {
+            case GAUGE:
+                return "gauge";
+            case COUNTER:
+                return "counter";
+            case SUMMARY:
+                return "summary";
+            case HISTOGRAM:
+                return "histogram";
+            default:
+                return "untyped";
+        }
+    }
+}


### PR DESCRIPTION
I made a version of the standalone http server that is able to cache results of scraping in order to avoid hammering the service behind (I mostly use it with cassandra) while still exposing the true timestamp of the scraping. I am aware of the staleness issue and to not go beyond 5min in the past.

I don't expect for this PR to be merged as is, I just release it for other people to be able to grab it if needed. 

Anyway let me know if you want to salvage something from this, most of the work is on MetricsServletCache.java