### PR TITLE
[Feature] configurable startup delay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 # compilation objects
 target/
 /.project
+dependency-reduced-pom.xml

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ See `./run_sample_httpserver.sh` for a sample script that runs the httpserver ag
 The configuration is in YAML. An example with all possible options:
 ```yaml
 ---
+startDelaySecs: 0
 hostPort: 127.0.0.1:1234
 jmxUrl: service:jmx:rmi:///jndi/rmi://127.0.0.1:1234/jmxrmi
 ssl: false
@@ -48,6 +49,7 @@ rules:
 ```
 Name     | Description
 ---------|------------
+startDelaySecs | start delay before serving requests. Any requests within the delay period will result in an empty metrics set.
 hostPort | The host and port to connect to via remote JMX. If neither this nor jmxUrl is specified, will talk to the local JVM.
 jmxUrl   | A full JMX URL to connect to. Should not be specified if hostPort is.
 ssl      | Whether JMX connection should be done over SSL. To configure certificates you have to set following system properties:<br/>`-Djavax.net.ssl.keyStore=/home/user/.keystore`<br/>`-Djavax.net.ssl.keyStorePassword=changeit`<br/>`-Djavax.net.ssl.trustStore=/home/user/.truststore`<br/>`-Djavax.net.ssl.trustStorePassword=changeit`

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -233,4 +233,17 @@ public class JmxCollectorTest {
       assertEquals(0.001, registry.getSampleValue("foo", new String[]{}, new String[]{}), .001);
     }
 
+    @Test(expected=IllegalStateException.class)
+    public void testDelayedStartNotReady() throws Exception {
+      JmxCollector jc = new JmxCollector("---\nstartDelaySeconds: 1").register(registry);
+      assertNull(registry.getSampleValue("boolean_Test_True", new String[]{}, new String[]{}));
+      fail();
+    }
+
+    @Test
+    public void testDelayedStartReady() throws Exception {
+      JmxCollector jc = new JmxCollector("---\nstartDelaySeconds: 1").register(registry);
+      Thread.sleep(2000);
+      assertEquals(1.0, registry.getSampleValue("boolean_Test_True", new String[]{}, new String[]{}), .001);
+    }
 }


### PR DESCRIPTION
@brian-brazil:
This is a first pass implementation of configurable startup delay for the JVM Agent.
It is intended to resolve #97 and #128

A few notes:
* There are no tests at this time (I will correct this shortly)
* There is no documentation for the property (coming)
* I had to implement the _Describable_ interface in the _Collector_ and return an empty list, breaking current behaviour which 'auto describes' JMX beans. This is only because the act of registering the JMX Collector results in a call to _collect_ as a side-effect. In my particular case it was important not to call _ManagementFactory.getPlatformMBeanServer_ before the delay expires (this is what resolves #128).

The way the code is currently structured, configuration is done at startup time and it is only the Agent Web Server that is started after the configured delay. Alternately it is possible to leave the _Collector_ as is and simply delay all configuration until the the timeout expires. This keeps existing behaviour and I'm happy to change if requested.