### PR TITLE
Use the type provided by the rule for the defaultExport

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See `./run_sample_httpserver.sh` for a sample script that runs the httpserver ag
 
 ## Configuration
 The configuration is in YAML. An example with all possible options:
-```
+```yaml
 ---
 hostPort: 127.0.0.1:1234
 jmxUrl: service:jmx:rmi:///jndi/rmi://127.0.0.1:1234/jmxrmi
@@ -63,7 +63,7 @@ value    | Value for the metric. Static values and capture groups from the `patt
 valueFactor | Optional number that `value` (or the scraped mBean value if `value` is not specified) is multiplied by, mainly used to convert mBean values from milliseconds to seconds.
 labels   | A map of label name to label value pairs. Capture groups from `pattern` can be used in each. `name` must be set to use this. Empty names and values are ignored. If not specified and the default format is not being used, no labels are set.
 help     | Help text for the metric. Capture groups from `pattern` can be used. `name` must be set to use this. Defaults to the mBean attribute decription and the full name of the attribute.
-type     | The type of the metric, can be `GAUGE` or `COUNTER`. `name` must be set to use this. Defaults to `GAUGE`.
+type     | The type of the metric, can be `GAUGE`, `COUNTER` or `UNTYPED`. `name` must be set to use this. Defaults to `UNTYPED`.
 
 Metric names and label names are sanitized. All characters other than `[a-zA-Z0-9:_]` are replaced with underscores,
 and adjacent underscores are collapsed. There's no limitations on label values or the help text.

--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -247,7 +247,8 @@ public class JmxCollector extends Collector {
           String attrName,
           String attrType,
           String help,
-          Object value) {
+          Object value,
+          Type type) {
         StringBuilder name = new StringBuilder();
         name.append(domain);
         if (beanProperties.size() > 0) {
@@ -284,7 +285,7 @@ public class JmxCollector extends Collector {
         }
 
         addSample(new MetricFamilySamples.Sample(fullname, labelNames, labelValues, ((Number)value).doubleValue()),
-          Type.GAUGE, help);
+          type, help);
       }
 
       public void recordBean(
@@ -333,7 +334,7 @@ public class JmxCollector extends Collector {
 
           // If there's no name provided, use default export format.
           if (rule.name == null) {
-            defaultExport(domain, beanProperties, attrKeys, rule.attrNameSnakeCase ? attrNameSnakeCase : attrName, attrType, help, value);
+            defaultExport(domain, beanProperties, attrKeys, rule.attrNameSnakeCase ? attrNameSnakeCase : attrName, attrType, help, value, rule.type);
             return;
           }
 

--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -44,7 +44,7 @@ public class JmxCollector extends Collector {
       Double valueFactor = 1.0;
       String help;
       boolean attrNameSnakeCase;
-      Type type = Type.GAUGE;
+      Type type = Type.UNTYPED;
       ArrayList<String> labelNames;
       ArrayList<String> labelValues;
     }


### PR DESCRIPTION
Hi @brian-brazil,

the current version of the jmx_exporter uses the type gauge for all metrics that match a rule that has no name configured and not the type configured for the rule. This PR fixes this.