### PR TITLE
javaagent: Handle containers that use custom MBeanServers

### DIFF
--- a/docs/Wildfly.md
+++ b/docs/Wildfly.md
@@ -1,0 +1,13 @@
+# Wildfly
+
+Wildfly 8,9 and 10 use a custom MBeanServer implementation. To use JMX Exporter:
+
+* As a _javaagent_ add:
+`-Djavax.management.builder.initial=io.prometheus.jmx.ContainerNotReadyYet` to the javaagent line.
+The class itself (ContainerNotReadyYet) does not exist and Wildfly overwrites the system property with a valid value during its startup. This *may* work with
+other containers that use custom MBeanServers.
+
+* As a remote scraper:
+Add the `jboss-cli-client.jar` from the Wildfly installation to the classpath of JMX Exporter and use the Wildfly version specific JMX URL in the configuration file.
+The JMX URL will be the same one as used to connect JConsole. The extra JAR is required because Wildfly uses a custom protocol to connect via the the HTTP(s) admin port.
+

--- a/example_configs/wildfly-10.yaml
+++ b/example_configs/wildfly-10.yaml
@@ -1,4 +1,5 @@
 ---
+# See docs/Wildfly.md for additional info
 lowercaseOutputName: true
 lowercaseOutputLabelNames: true
 rules:


### PR DESCRIPTION
@brian-brazil 
Some containers (e.g. Wildfly 8, 9, 10) use a custom MBeanServer.
The simplest way to deal with this is to ask the user to set the factory
to either the correct class (if known) or a non-existant class and let the
container intialisation process correct it.

Any call to Management.getPlatformMBeanServer() before the container is
ready will then fail with a ClassNotFoundException until container
initialisation is complete.

In terms of scraping we swallow the resulting ClassNotFoundException to avoid
polluting the container's logs. If there happens to be a scrape the caller will
get an empty page with no metrics

Fixes #128