### PR TITLE
Re-fix #124 by limiting the number of threads that can run Jetty

### DIFF
--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -45,7 +45,9 @@ public class JavaAgent {
      pool.setName("jmx_exporter");
      server = new Server(pool);
 
-     ServerConnector connector = new ServerConnector(server);
+     // Hard code the number of selectors to avoid running too many threads
+     // https://github.com/prometheus/jmx_exporter/pull/124
+     ServerConnector connector = new ServerConnector(server, 0, 4);
      connector.setReuseAddress(true);
      connector.setHost(host);
      connector.setPort(port);


### PR DESCRIPTION
In response to #148 and tested on a 32 cores machine.
I set the number of acceptor to 0 meaning that it will use the selectors threads and the number of selectors to 4.

Why 4 ? Because internally there is other threads used and if we go higher than 5 we run into the same issue (too many threads max=10)? 4 is also the default value for jetty in the code.

I wanted to add a test by overriding the Runtime.getAvailableProcessor methods in the integration test. But sadly, the class was design against that and it is not possible to override the value  at the jvm level https://bugs.openjdk.java.net/browse/JDK-8157478