### PR TITLE
Revert: "Add gzip compression on jetty (#137, #139)" to restore java 1.6 compatibility

### DIFF
--- a/jmx_prometheus_httpserver/pom.xml
+++ b/jmx_prometheus_httpserver/pom.xml
@@ -28,12 +28,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.3.v20170317</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
-      <version>6.1.26</version>
+      <version>8.1.7.v20120910</version>
     </dependency>
   </dependencies>
 

--- a/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
+++ b/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
@@ -4,7 +4,6 @@ import io.prometheus.client.exporter.MetricsServlet;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.mortbay.servlet.GzipFilter;
 
 import java.io.File;
 import java.net.InetSocketAddress;
@@ -34,7 +33,6 @@ public class WebServer {
      Server server = new Server(socket);
      ServletContextHandler context = new ServletContextHandler();
      context.setContextPath("/");
-     context.addFilter(GzipFilter.class, "/*", null);
      server.setHandler(context);
      context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
      server.start();

--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -33,13 +33,8 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.3.v20170317</version>
+      <version>8.1.7.v20120910</version>
     </dependency>
-      <dependency> <!-- For GZip compression -->
-          <groupId>org.mortbay.jetty</groupId>
-          <artifactId>jetty-util</artifactId>
-          <version>6.1.26</version>
-      </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -66,7 +61,7 @@
       <plugin>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-shade-plugin</artifactId>
-      <version>2.4</version>
+      <version>2.3</version>
       <executions>
       <execution>
         <phase>package</phase>
@@ -83,7 +78,6 @@
                 <include>javax.servlet.**</include>
                 <include>org.eclipse.**</include>
                 <include>org.yaml.**</include>
-                <include>org.mortbay.**</include>
               </includes>
               <excludes>
                 <exclude>io.prometheus.jmx.shaded.**</exclude>

--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -4,13 +4,12 @@ import io.prometheus.client.exporter.MetricsServlet;
 import io.prometheus.client.hotspot.DefaultExports;
 import java.lang.instrument.Instrumentation;
 import java.io.File;
-import org.eclipse.jetty.server.Connector;
+import java.net.InetSocketAddress;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.nio.SelectChannelConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.mortbay.servlet.GzipFilter;
 
 public class JavaAgent {
    static Server server;
@@ -22,41 +21,39 @@ public class JavaAgent {
        System.exit(1);
      }
 
-     String host;
      int port;
+     InetSocketAddress socket;
      String file;
 
      if (args.length == 3) {
        port = Integer.parseInt(args[1]);
-       host = args[0];
+       socket = new InetSocketAddress(args[0], port);
        file = args[2];
      } else {
        port = Integer.parseInt(args[0]);
-       host = "0.0.0.0";
+       socket = new InetSocketAddress(port);
        file = args[1];
      }
 
      new JmxCollector(new File(file)).register();
      DefaultExports.initialize();
 
+     server = new Server();
      QueuedThreadPool pool = new QueuedThreadPool();
      pool.setDaemon(true);
      pool.setMaxThreads(10);
+     pool.setMaxQueued(10);
      pool.setName("jmx_exporter");
-     server = new Server(pool);
-
-     ServerConnector connector = new ServerConnector(server);
-     connector.setReuseAddress(true);
-     connector.setHost(host);
-     connector.setPort(port);
-     server.setConnectors(new Connector[]{connector});
-
+     server.setThreadPool(pool);
+     SelectChannelConnector connector = new SelectChannelConnector();
+     connector.setHost(socket.getHostName());
+     connector.setPort(socket.getPort());
+     connector.setAcceptors(1);
+     server.addConnector(connector);
      ServletContextHandler context = new ServletContextHandler();
      context.setContextPath("/");
-     context.addFilter(GzipFilter.class, "/*", null);
      server.setHandler(context);
      context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
-
      server.start();
    }
 }

--- a/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/JavaAgentIT.java
+++ b/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/JavaAgentIT.java
@@ -6,7 +6,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -72,9 +71,7 @@ public class JavaAgentIT {
             // Wait for application to start
             app.getInputStream().read();
 
-            URL uri = new URL("http://localhost:" + port + "/metrics");
-            HttpURLConnection cnx = (HttpURLConnection) uri.openConnection();
-            InputStream stream = cnx.getInputStream();
+            InputStream stream = new URL("http://localhost:" + port + "/metrics").openStream();
             BufferedReader contents = new BufferedReader(new InputStreamReader(stream));
             boolean found = false;
             while (!found) {
@@ -90,15 +87,11 @@ public class JavaAgentIT {
             assertThat("Expected metric not found", found);
 
             // Tell application to stop
-            cnx.disconnect();
             app.getOutputStream().write('\n');
             try {
                 app.getOutputStream().flush();
             } catch (IOException ignored) {
             }
-        } catch (Throwable ex) {
-            assertThat("Expection caught during scraping", false);
-            ex.printStackTrace();
         } finally {
             final int exitcode = app.waitFor();
             // Log any errors printed

--- a/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/TestApplication.java
+++ b/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/TestApplication.java
@@ -7,6 +7,5 @@ public class TestApplication {
         System.out.println();
         System.out.flush();
         System.in.read();
-        System.exit(0);
     }
 }


### PR DESCRIPTION
It is reverting the following
  + Gzip compression
  + Usage of ReuseAddress port for the http server
  +  bump of maven-shade plugin

This reverts commit 
e4f8280b52ac208c24ebbff4fb1be28ea0fe667d
fde351f805e46b59f85d76fcee07ffa93c83aef6