### PR TITLE
Use simple HTTP Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@
 
 # compilation objects
 target/
-/.project
+.project
+.settings/
+.classpath
 dependency-reduced-pom.xml

--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
-      <version>0.0.21</version>
+      <version>0.0.25</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/jmx_prometheus_httpserver/pom.xml
+++ b/jmx_prometheus_httpserver/pom.xml
@@ -7,7 +7,6 @@
     <version>0.10-SNAPSHOT</version>
   </parent>
 
-  <groupId>io.prometheus.jmx</groupId>
   <artifactId>jmx_prometheus_httpserver</artifactId>
   <description>
     See https://github.com/prometheus/jmx_exporter/blob/master/README.md
@@ -26,9 +25,9 @@
       <version>0.0.21</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-      <version>8.1.7.v20120910</version>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_httpserver</artifactId>
+      <version>0.0.9-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/jmx_prometheus_httpserver/pom.xml
+++ b/jmx_prometheus_httpserver/pom.xml
@@ -21,11 +21,6 @@
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient_servlet</artifactId>
-      <version>0.0.25</version>
-    </dependency>
-    <dependency>
-      <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
       <version>0.0.25</version>
     </dependency>

--- a/jmx_prometheus_httpserver/pom.xml
+++ b/jmx_prometheus_httpserver/pom.xml
@@ -22,12 +22,12 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_servlet</artifactId>
-      <version>0.0.26-SNAPSHOT</version>
+      <version>0.0.25</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
-      <version>0.0.26-SNAPSHOT</version>
+      <version>0.0.25</version>
     </dependency>
   </dependencies>
 

--- a/jmx_prometheus_httpserver/pom.xml
+++ b/jmx_prometheus_httpserver/pom.xml
@@ -22,12 +22,12 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_servlet</artifactId>
-      <version>0.0.21</version>
+      <version>0.0.26-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
-      <version>0.0.9-SNAPSHOT</version>
+      <version>0.0.26-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
+++ b/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
@@ -1,12 +1,9 @@
 package io.prometheus.jmx;
 
-import io.prometheus.client.exporter.MetricsServlet;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
-
 import java.io.File;
 import java.net.InetSocketAddress;
+
+import io.prometheus.client.exporter.HTTPServer;
 
 public class WebServer {
 
@@ -30,12 +27,6 @@ public class WebServer {
 
      JmxCollector jc = new JmxCollector(new File(args[1])).register();
 
-     Server server = new Server(socket);
-     ServletContextHandler context = new ServletContextHandler();
-     context.setContextPath("/");
-     server.setHandler(context);
-     context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
-     server.start();
-     server.join();
+     HTTPServer server = new HTTPServer(port);
    }
 }

--- a/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
+++ b/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
@@ -1,7 +1,9 @@
 package io.prometheus.jmx;
 
 import java.io.File;
+import java.net.InetSocketAddress;
 
+import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.HTTPServer;
 
 public class WebServer {
@@ -14,14 +16,24 @@ public class WebServer {
 
      String[] hostnamePort = args[0].split(":");
      int port;
-
+     InetSocketAddress socket;
+     
      if (hostnamePort.length == 2) {
        port = Integer.parseInt(hostnamePort[1]);
+       socket = new InetSocketAddress(hostnamePort[0], port);
      } else {
        port = Integer.parseInt(hostnamePort[0]);
+       socket = new InetSocketAddress(port);
      }
 
-     JmxCollector jc = new JmxCollector(new File(args[1])).register();
-     HTTPServer server = new HTTPServer(port);
+     new JmxCollector(new File(args[1])).register();
+     final HTTPServer server = new HTTPServer(socket, CollectorRegistry.defaultRegistry);
+     
+     Runtime.getRuntime().addShutdownHook(new Thread() {
+         @Override
+         public void run() {
+           server.stop();
+         }
+       });
    }
 }

--- a/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
+++ b/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
@@ -27,13 +27,6 @@ public class WebServer {
      }
 
      new JmxCollector(new File(args[1])).register();
-     final HTTPServer server = new HTTPServer(socket, CollectorRegistry.defaultRegistry);
-     
-     Runtime.getRuntime().addShutdownHook(new Thread() {
-         @Override
-         public void run() {
-           server.stop();
-         }
-       });
+     new HTTPServer(socket, CollectorRegistry.defaultRegistry);
    }
 }

--- a/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
+++ b/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
@@ -1,7 +1,6 @@
 package io.prometheus.jmx;
 
 import java.io.File;
-import java.net.InetSocketAddress;
 
 import io.prometheus.client.exporter.HTTPServer;
 
@@ -15,18 +14,14 @@ public class WebServer {
 
      String[] hostnamePort = args[0].split(":");
      int port;
-     InetSocketAddress socket;
 
      if (hostnamePort.length == 2) {
        port = Integer.parseInt(hostnamePort[1]);
-       socket = new InetSocketAddress(hostnamePort[0], port);
      } else {
        port = Integer.parseInt(hostnamePort[0]);
-       socket = new InetSocketAddress(port);
      }
 
      JmxCollector jc = new JmxCollector(new File(args[1])).register();
-
      HTTPServer server = new HTTPServer(port);
    }
 }

--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -27,11 +27,6 @@
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient_servlet</artifactId>
-      <version>0.0.25</version>
-    </dependency>
-    <dependency>
-      <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
       <version>0.0.25</version>
     </dependency>

--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -52,8 +52,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
 

--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -31,9 +31,9 @@
       <version>0.0.21</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-      <version>8.1.7.v20120910</version>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_httpserver</artifactId>
+      <version>0.0.9-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -23,17 +23,17 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_hotspot</artifactId>
-      <version>0.0.26-SNAPSHOT</version>
+      <version>0.0.25</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_servlet</artifactId>
-      <version>0.0.26-SNAPSHOT</version>
+      <version>0.0.25</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
-      <version>0.0.26-SNAPSHOT</version>
+      <version>0.0.25</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -23,17 +23,17 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_hotspot</artifactId>
-      <version>0.0.21</version>
+      <version>0.0.26-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_servlet</artifactId>
-      <version>0.0.21</version>
+      <version>0.0.26-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
-      <version>0.0.9-SNAPSHOT</version>
+      <version>0.0.26-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -35,14 +35,6 @@ public class JavaAgent {
 
      new JmxCollector(new File(file)).register();
      DefaultExports.initialize();
-
      server = new HTTPServer(socket, CollectorRegistry.defaultRegistry);
-     
-     Runtime.getRuntime().addShutdownHook(new Thread() {
-         @Override
-         public void run() {
-           server.stop();
-         }
-       });
    }
 }

--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -2,11 +2,14 @@ package io.prometheus.jmx;
 
 import java.io.File;
 import java.lang.instrument.Instrumentation;
+import java.net.InetSocketAddress;
 
+import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.HTTPServer;
 import io.prometheus.client.hotspot.DefaultExports;
 
 public class JavaAgent {
+   
    static HTTPServer server;
 
    public static void premain(String agentArgument, Instrumentation instrumentation) throws Exception {
@@ -18,18 +21,28 @@ public class JavaAgent {
 
      int port;
      String file;
+     InetSocketAddress socket;
 
      if (args.length == 3) {
        port = Integer.parseInt(args[1]);
+       socket = new InetSocketAddress(args[0], port);
        file = args[2];
      } else {
        port = Integer.parseInt(args[0]);
+       socket = new InetSocketAddress(port);
        file = args[1];
      }
 
      new JmxCollector(new File(file)).register();
      DefaultExports.initialize();
 
-     server = new HTTPServer(port);
+     server = new HTTPServer(socket, CollectorRegistry.defaultRegistry);
+     
+     Runtime.getRuntime().addShutdownHook(new Thread() {
+         @Override
+         public void run() {
+           server.stop();
+         }
+       });
    }
 }

--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -1,18 +1,13 @@
 package io.prometheus.jmx;
 
-import io.prometheus.client.exporter.MetricsServlet;
-import io.prometheus.client.hotspot.DefaultExports;
-import java.lang.instrument.Instrumentation;
 import java.io.File;
-import java.net.InetSocketAddress;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.nio.SelectChannelConnector;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import java.lang.instrument.Instrumentation;
+
+import io.prometheus.client.exporter.HTTPServer;
+import io.prometheus.client.hotspot.DefaultExports;
 
 public class JavaAgent {
-   static Server server;
+   static HTTPServer server;
 
    public static void premain(String agentArgument, Instrumentation instrumentation) throws Exception {
      String[] args = agentArgument.split(":");
@@ -22,38 +17,19 @@ public class JavaAgent {
      }
 
      int port;
-     InetSocketAddress socket;
      String file;
 
      if (args.length == 3) {
        port = Integer.parseInt(args[1]);
-       socket = new InetSocketAddress(args[0], port);
        file = args[2];
      } else {
        port = Integer.parseInt(args[0]);
-       socket = new InetSocketAddress(port);
        file = args[1];
      }
 
      new JmxCollector(new File(file)).register();
      DefaultExports.initialize();
 
-     server = new Server();
-     QueuedThreadPool pool = new QueuedThreadPool();
-     pool.setDaemon(true);
-     pool.setMaxThreads(10);
-     pool.setMaxQueued(10);
-     pool.setName("jmx_exporter");
-     server.setThreadPool(pool);
-     SelectChannelConnector connector = new SelectChannelConnector();
-     connector.setHost(socket.getHostName());
-     connector.setPort(socket.getPort());
-     connector.setAcceptors(1);
-     server.addConnector(connector);
-     ServletContextHandler context = new ServletContextHandler();
-     context.setContextPath("/");
-     server.setHandler(context);
-     context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
-     server.start();
+     server = new HTTPServer(port);
    }
 }


### PR DESCRIPTION
Motivation:
https://github.com/prometheus/jmx_exporter/issues/155

Modifications:
Changed the code of both the agent and external HTTP process to use the simple HTTP server provided on https://github.com/prometheus/client_java/pull/73

Result:
JMX exporter works with the simple HTTP Server.