### PR TITLE
Docker Image for HTTP exporter

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,29 @@
+FROM openjdk:8u131-jdk-alpine
+
+MAINTAINER "Amit Mor" <amimimor@gmail.com>
+
+RUN apk update && apk add bash maven
+ARG RUNDIR
+ENV RUNDIR ${RUNDIR:-/usr/local/jmx_exporter}
+WORKDIR $RUNDIR
+ADD jmx_prometheus_httpserver/ jmx_prometheus_httpserver/
+ADD jmx_prometheus_javaagent/ jmx_prometheus_javaagent/
+ADD collector/ collector/
+ADD pom.xml pom.xml
+# get the version from the pom.xml
+ENV mvn_evaluate "org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate  -Dexpression=project.version"
+# let maven import the plugin dependcies
+RUN mvn $mvn_evaluate > /dev/null
+# extract the project version and pass it into the container as env var, to be consumed by the start.sh script
+RUN VERSION=$(mvn $mvn_evaluate | grep -v -e "^\[INFO\]") && echo export JMX_PROMETHEUS_VERSION=$VERSION > /root/.bashrc && printf "\nFound version: %s" $VERSION
+# compile
+RUN mvn compile package
+ADD docker/start.sh /start.sh
+RUN chmod +x /start.sh
+# config volume
+RUN mkdir -p $RUNDIR/jmx_prometheus_httpserver/config/ 
+VOLUME $RUNDIR/jmx_prometheus_httpserver/config/
+# ports
+EXPOSE 39390
+# cmd
+CMD /start.sh

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -x
+
+mvn_evaluate="org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate  -Dexpression=project.version"
+mvn $mvn_evaluate > /dev/null
+VERSION=$(mvn $mvn_evaluate | grep -v -e "^\[INFO\]") 
+
+docker build -t amimimor/jmx-prometheus:$VERSION -f docker/Dockerfile .
+

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Script to run a java application for testing jmx4prometheus.
+env
+
+RUNDIR=${RUNDIR:-/usr/local/jmx_exporter}
+echo RUNDIR $RUNDIR
+BIND_HOST=${BIND_HOST:-localhost}
+echo BINDING TO HOST:PORT $BIND_HOST:39390
+CONFIG_FILE_DIR=${CONFIG_FILE_DIR:-/usr/local/jmx_exporter/jmx_prometheus_httpserver/config/config.yml}
+echo GOING TO USE $CONFIG_FILE_DIR AS INPUT CONFIG 
+VERSION=$JMX_PROMETHEUS_VERSION
+echo using jar jmx_prometheus_httpserver-${VERSION}-jar-with-dependencies.jar
+java -jar  $RUNDIR/jmx_prometheus_httpserver/target/jmx_prometheus_httpserver-${VERSION}-jar-with-dependencies.jar $BIND_HOST $CONFIG_FILE_DIR
+


### PR DESCRIPTION
I've created a dir named 'docker' that contains the necessary files to build and run a Docker container of the http exporter. If the PR is of interest, I would happily add docs on the correct 'docker build ...' cmd as well as the 'docker run ...' cmd as I've already outlined in [my docker hub repo](https://hub.docker.com/r/amimimor/jmx-prometheus/). Currently the image is hosted on my docker hub account. If you'd like I can change the builder to create the image under a different account (prometheus?)