### PR TITLE
Servlet path for Java agent can be configured by runtimes args.

### DIFF
--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -2,58 +2,98 @@ package io.prometheus.jmx;
 
 import io.prometheus.client.exporter.MetricsServlet;
 import io.prometheus.client.hotspot.DefaultExports;
-import java.lang.instrument.Instrumentation;
-import java.io.File;
-import java.net.InetSocketAddress;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.nio.SelectChannelConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
+import java.io.File;
+import java.lang.instrument.Instrumentation;
+import java.net.InetSocketAddress;
+
 public class JavaAgent {
-   static Server server;
 
-   public static void premain(String agentArgument, Instrumentation instrumentation) throws Exception {
-     String[] args = agentArgument.split(":");
-     if (args.length < 2 || args.length > 3) {
-       System.err.println("Usage: -javaagent:/path/to/JavaAgent.jar=[host:]<port>:<yaml configuration file>");
-       System.exit(1);
-     }
+    static final String DEFAULT_SERVLET_PATH = "/metrics";
 
-     int port;
-     InetSocketAddress socket;
-     String file;
+    static Server server;
 
-     if (args.length == 3) {
-       port = Integer.parseInt(args[1]);
-       socket = new InetSocketAddress(args[0], port);
-       file = args[2];
-     } else {
-       port = Integer.parseInt(args[0]);
-       socket = new InetSocketAddress(port);
-       file = args[1];
-     }
+    public static void premain(String agentArgument, Instrumentation instrumentation) throws Exception {
+        String[] args = agentArgument.split(":");
+        if (args.length < 2 || args.length > 4) {
+            System.err.println("Usage: -javaagent:/path/to/JavaAgent.jar=[host:]<port>:[/path]:<yaml configuration file>");
+            System.exit(1);
+        }
 
-     new JmxCollector(new File(file)).register();
-     DefaultExports.initialize();
+        ConfigArgs config = new ConfigArgs(args);
 
-     server = new Server();
-     QueuedThreadPool pool = new QueuedThreadPool();
-     pool.setDaemon(true);
-     pool.setMaxThreads(10);
-     pool.setMaxQueued(10);
-     pool.setName("jmx_exporter");
-     server.setThreadPool(pool);
-     SelectChannelConnector connector = new SelectChannelConnector();
-     connector.setHost(socket.getHostName());
-     connector.setPort(socket.getPort());
-     connector.setAcceptors(1);
-     server.addConnector(connector);
-     ServletContextHandler context = new ServletContextHandler();
-     context.setContextPath("/");
-     server.setHandler(context);
-     context.addServlet(new ServletHolder(new MetricsServlet()), "/metrics");
-     server.start();
-   }
+        new JmxCollector(new File(config.file)).register();
+        DefaultExports.initialize();
+
+        server = new Server();
+        QueuedThreadPool pool = new QueuedThreadPool();
+        pool.setDaemon(true);
+        pool.setMaxThreads(10);
+        pool.setMaxQueued(10);
+        pool.setName("jmx_exporter");
+        server.setThreadPool(pool);
+        SelectChannelConnector connector = new SelectChannelConnector();
+        connector.setHost(config.hostname());
+        connector.setPort(config.port());
+        connector.setAcceptors(1);
+        server.addConnector(connector);
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/");
+        server.setHandler(context);
+        context.addServlet(new ServletHolder(new MetricsServlet()), config.path);
+        server.start();
+    }
+
+    static class ConfigArgs {
+
+        InetSocketAddress socket;
+        String file;
+        String path = DEFAULT_SERVLET_PATH;
+
+        public ConfigArgs(String[] args) {
+            int length = args.length;
+            file = args[length - 1];
+            if (length == 4) {
+                setSocket(args[0], args[1]);
+                path = args[2];
+            } else if (length == 2) {
+                setSocket(args[0]);
+            } else if (args[1].startsWith("/")) {
+                setSocket(args[0]);
+                path = args[1];
+            } else {
+                setSocket(args[0], args[1]);
+            }
+        }
+
+        String hostname() {
+            return socket.getHostName();
+        }
+
+        int port() {
+            return socket.getPort();
+        }
+
+        String path() {
+            return path;
+        }
+
+        String file() {
+            return file;
+        }
+
+        private void setSocket(String port) {
+            this.socket = new InetSocketAddress(Integer.parseInt(port));
+        }
+
+        private void setSocket(String host, String port) {
+            this.socket = new InetSocketAddress(host, Integer.parseInt(port));
+        }
+
+    }
 }

--- a/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/JavaAgentTest.java
+++ b/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/JavaAgentTest.java
@@ -1,0 +1,40 @@
+package io.prometheus.jmx;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class JavaAgentTest {
+
+    @Test
+    public void testConfig() throws IOException, InterruptedException {
+        JavaAgent.ConfigArgs config4Params = new JavaAgent.ConfigArgs(
+                "myhost:9876:/servlet/path:myconfig.yaml".split(":"));
+        assertThat(config4Params.hostname(), CoreMatchers.equalTo("myhost"));
+        assertThat(config4Params.port(), CoreMatchers.equalTo(9876));
+        assertThat(config4Params.path(), CoreMatchers.equalTo("/servlet/path"));
+        assertThat(config4Params.file(), CoreMatchers.equalTo("myconfig.yaml"));
+
+        JavaAgent.ConfigArgs configNoHost = new JavaAgent.ConfigArgs(
+                "9876:/servlet/path:myconfig.yaml".split(":"));
+        assertThat(configNoHost.port(), CoreMatchers.equalTo(9876));
+        assertThat(configNoHost.path(), CoreMatchers.equalTo("/servlet/path"));
+        assertThat(configNoHost.file(), CoreMatchers.equalTo("myconfig.yaml"));
+
+        JavaAgent.ConfigArgs configNoPath = new JavaAgent.ConfigArgs(
+                "myhost:9876:myconfig.yaml".split(":"));
+        assertThat(configNoPath.hostname(), CoreMatchers.equalTo("myhost"));
+        assertThat(configNoPath.port(), CoreMatchers.equalTo(9876));
+        assertThat(configNoPath.path(), CoreMatchers.equalTo(JavaAgent.DEFAULT_SERVLET_PATH));
+        assertThat(configNoPath.file(), CoreMatchers.equalTo("myconfig.yaml"));
+
+        JavaAgent.ConfigArgs config2Params = new JavaAgent.ConfigArgs(
+                "9876:myconfig.yaml".split(":"));
+        assertThat(config2Params.port(), CoreMatchers.equalTo(9876));
+        assertThat(config2Params.path(), CoreMatchers.equalTo(JavaAgent.DEFAULT_SERVLET_PATH));
+        assertThat(config2Params.file(), CoreMatchers.equalTo("myconfig.yaml"));
+    }
+}


### PR DESCRIPTION
@brian-brazil,

JMX exporter works great in our project as Java agent, but we need to be able to change the servlet path (currently it is "/metrics"). Hope this PR is helpful. Otherwise please tell me what needs to be changed. Thanks in advance.

Oliver