### PR TITLE
Fix rule pattern in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ lowercaseOutputLabelNames: false
 whitelistObjectNames: ["org.apache.cassandra.metrics:*"]
 blacklistObjectNames: ["org.apache.cassandra.metrics:type=ColumnFamily,*"]
 rules:
-  - pattern: "^org.apache.cassandra.metrics<type=(\w+), name=(\w+)><>Value: (\d+)"
+  - pattern: 'org.apache.cassandra.metrics<type=(\w+), name=(\w+)><>Value: (\d+)'
     name: cassandra_$1_$2
     value: $3
     valueFactor: 0.001


### PR DESCRIPTION
The `^` is added to the pattern in the code, so I guess it is redundant.

https://github.com/prometheus/jmx_exporter/blob/a7b038f90f7b49dda1f9bfaf4089f159f0686d6e/collector/src/main/java/io/prometheus/jmx/JmxCollector.java#L170

I am getting following exception, when using double quotes:

```
"jboss.jca<service=ManagedConnectionPool, name=(\w+)><>AvailableConnectionCount: (\d+)"
```

```
Exception in thread "main" while scanning a double-quoted scalar
 in 'reader', line 9, column 12:
    - pattern: "jboss.jca<service=ManagedConnec ...
               ^
found unknown escape character w(119)
 in 'reader', line 9, column 61:
     ... e=ManagedConnectionPool, name=(\w+)><>AvailableConnectionCount:  ...
                                         ^

        at org.yaml.snakeyaml.scanner.ScannerImpl.scanFlowScalarNonSpaces(ScannerImpl.java:1906)
        at org.yaml.snakeyaml.scanner.ScannerImpl.scanFlowScalar(ScannerImpl.java:1846)
        at org.yaml.snakeyaml.scanner.ScannerImpl.fetchFlowScalar(ScannerImpl.java:1029)
        at org.yaml.snakeyaml.scanner.ScannerImpl.fetchDouble(ScannerImpl.java:1011)
        at org.yaml.snakeyaml.scanner.ScannerImpl.fetchMoreTokens(ScannerImpl.java:396)
        at org.yaml.snakeyaml.scanner.ScannerImpl.checkToken(ScannerImpl.java:226)
        at org.yaml.snakeyaml.parser.ParserImpl$ParseBlockMappingValue.produce(ParserImpl.java:586)
        at org.yaml.snakeyaml.parser.ParserImpl.peekEvent(ParserImpl.java:158)
        at org.yaml.snakeyaml.parser.ParserImpl.checkEvent(ParserImpl.java:143)
        at org.yaml.snakeyaml.composer.Composer.composeNode(Composer.java:132)
        at org.yaml.snakeyaml.composer.Composer.composeMappingNode(Composer.java:229)
        at org.yaml.snakeyaml.composer.Composer.composeNode(Composer.java:155)
        at org.yaml.snakeyaml.composer.Composer.composeSequenceNode(Composer.java:199)
        at org.yaml.snakeyaml.composer.Composer.composeNode(Composer.java:153)
        at org.yaml.snakeyaml.composer.Composer.composeMappingNode(Composer.java:229)
        at org.yaml.snakeyaml.composer.Composer.composeNode(Composer.java:155)
        at org.yaml.snakeyaml.composer.Composer.composeDocument(Composer.java:122)
        at org.yaml.snakeyaml.composer.Composer.getSingleNode(Composer.java:105)
        at org.yaml.snakeyaml.constructor.BaseConstructor.getSingleData(BaseConstructor.java:120)
        at org.yaml.snakeyaml.Yaml.loadFromReader(Yaml.java:450)
        at org.yaml.snakeyaml.Yaml.load(Yaml.java:393)
        at io.prometheus.jmx.JmxCollector.<init>(JmxCollector.java:74)
        at io.prometheus.jmx.WebServer.main(WebServer.java:29)
```

Works with single quotes though.

```
'jboss.jca<service=ManagedConnectionPool, name=(\w+)><>AvailableConnectionCount: (\d+)'
```
