### PR TITLE
Only retrieve mbeans and attributes that match rules.

### DIFF
--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -162,7 +162,27 @@ public class JmxCollectorTest {
       assertNull(registry.getSampleValue("hadoop_DataNode_replaceBlockOpMinTime", new String[]{"name"}, new String[]{"DataNodeActivity-ams-hdd001-50010"}));
     }
 
-    @Test
+  @Test
+  public void testWhitelistWithoutPatterns() throws Exception {
+    JmxCollector jc = new JmxCollector("\n---\nwhitelistObjectNames:\n- org.apache.cassandra.metrics:type=Compaction,name=CompletedTasks".replace('`','"')).register(registry);
+
+    // Test what should and shouldn't be present.
+    assertNotNull(registry.getSampleValue("org_apache_cassandra_metrics_Compaction_Value", new String[]{"name"}, new String[]{"CompletedTasks"}));
+    assertNull(registry.getSampleValue("hadoop_DataNode_replaceBlockOpMinTime", new String[]{"name"}, new String[]{"DataNodeActivity-ams-hdd001-50010"}));
+  }
+
+  @Test
+  public void testMBeanInfoCache() throws Exception {
+    JmxCollector jc = new JmxCollector("\n---\nwhitelistObjectNames:\n- org.apache.cassandra.metrics:type=Compaction,name=CompletedTasks".replace('`','"')).register(registry);
+    assertThat(jc.getmBeanInfoCache().size(), CoreMatchers.equalTo(0));
+
+    assertNotNull(registry.getSampleValue("org_apache_cassandra_metrics_Compaction_Value", new String[]{"name"}, new String[]{"CompletedTasks"}));
+    assertThat(jc.getmBeanInfoCache().size(), CoreMatchers.equalTo(1));
+  }
+
+
+
+  @Test
     public void testBlacklist() throws Exception {
       JmxCollector jc = new JmxCollector("\n---\nwhitelistObjectNames:\n- java.lang:*\n- org.apache.cassandra.concurrent:*\nblacklistObjectNames:\n- org.apache.cassandra.concurrent:*".replace('`','"')).register(registry);
 


### PR DESCRIPTION
This approach reduced the scape time on my (jboss) setup to about 25% (4 times less).

Change-Id: Ia3a933d2ba0e38143847f98bbd21ba4061056ea1