### PR TITLE
Support labels that contain tokens to be replaced with sysprops and env vars

### DIFF
--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -110,6 +110,16 @@ public class JmxCollectorTest {
     }
 
     @Test
+    public void testEnvAndSysPropLabelNames() throws Exception {
+      String home = System.getenv("USER");
+      String testProp = "wotGorilla";
+      System.setProperty("test.Prop", testProp);
+      JmxCollector jc = new JmxCollector(
+              "\n---\nrules:\n- pattern: `^hadoop<service=DataNode, name=DataNodeActivity-ams-hdd001-50010><>replaceBlockOpMinTime:`\n  name: Foo\n  labels:\n    ${sysprop.test.Prop}BB${env.USER}CC${env.UNKNOWN_ENV_HERE}DD${sysprop.UNKNOWN_PROP_HERE}EE${sysprop.SOME_UNKNOWN_PROP:abc}${env.SOME_UNKNOWN_ENV:xyz}: ${sysprop.test.Prop}WW${env.USER}XX${env.SOME_UNKNOWN_ENV}YY${sysprop.SOME_UNKNOWN_PROP}ZZ${sysprop.SOME_UNKNOWN_PROP:abc}${env.SOME_UNKNOWN_ENV:xyz}".replace('`','"')).register(registry);
+      assertEquals(200, registry.getSampleValue("Foo", new String[]{testProp + "BB" + home + "CCDDEEabcxyz"}, new String[]{testProp + "WW" + home + "XXYYZZabcxyz"}), .001);
+    }
+
+    @Test
     public void testHelpFromPattern() throws Exception {
       JmxCollector jc = new JmxCollector(
               "\n---\nrules:\n- pattern: `^(hadoop)<service=DataNode, name=DataNodeActivity-ams-hdd001-50010><>replaceBlockOpMinTime:`\n  name: foo\n  help: bar $1".replace('`','"')).register(registry);


### PR DESCRIPTION
@brian-brazil 

This allows the JMX exporter to be told to create label names or values that contain values derived from Java system properties and operating system environment variables.

If a label (name or value) has within it a token in the form `${env.ABC}` it will be replaced with the value of the environment variable "ABC". If no environment variable named "ABC" exists then the token is replaced with a default value or empty string if no default is specified. To define a default, place it after the environment variable name separated with a colon, e.g. `${env.ABC:my-default}`.

The analogous functionality exists for system properties. e.g. `${sysprop.XYZ}` or `${sysprop.XYZ:my-default}`.

If a given label name or value has multiple tokens, they are all replaced.

For example, if a label name or value is defined as:

`user_${env.USER}_something_${sysprop.foo.bar}_${env.UNK:xyz}`

and the environment variable "USER" has a value of "bob", the Java system property "foo.bar" has a value of "123", and there is no environment variable named "UNK" then the label name or value will be:

`user_bob_something_123_xyz`

Another artificial, but more realistic, use case is:

```
labels:
  user: ${env.USER:anonymous}
  datacenter: ${sysprop.data.center}
  ${env.CORP_NAME}_${env.CORP_GROUP}: uxf_${env.CORP_ID:unknown}
```

This is useful when you want to attach additional metadata to your JMX rules such that your timeseries can be further refined based on system properties or environment variables set in the MBeanServer JVM. I can also see this being useful within Kubernetes or OpenShift pods running the Java app (passing in env vars or sys props defined by the pod template to help make the timeseries unique across pods, as an example).
