### PR TITLE
Added tracking of Undertow Xnio metrics

### DIFF
--- a/example_configs/wildfly-10.yaml
+++ b/example_configs/wildfly-10.yaml
@@ -25,3 +25,15 @@ rules:
       server: $1
       http_listener: $2
 
+  - pattern: "^org.xnio<type=Xnio, provider=\"nio\", worker=(.+)><>(.+_size|.+_count):"
+    attrNameSnakeCase: true
+    name: wildfly_xnio_$2
+    labels:
+      worker: $1
+
+  - pattern: "^org.xnio<type=Xnio, provider=\"nio\", worker=(.+), address=(.+)><>(.+_count):"
+    attrNameSnakeCase: true
+    name: wildfly_xnio_$3
+    labels:
+      worker: $1
+      address: $2


### PR DESCRIPTION
Adds these metrics:
```
# HELP wildfly_xnio_io_thread_count IoThreadCount (org.xnio<type=Xnio, provider="nio", worker="management"><>IoThreadCount)
# TYPE wildfly_xnio_io_thread_count untyped
wildfly_xnio_io_thread_count{worker="\"management\"",} 2.0
wildfly_xnio_io_thread_count{worker="\"default\"",} 8.0
# HELP wildfly_xnio_core_worker_pool_size CoreWorkerPoolSize (org.xnio<type=Xnio, provider="nio", worker="management"><>CoreWorkerPoolSize)
# TYPE wildfly_xnio_core_worker_pool_size untyped
wildfly_xnio_core_worker_pool_size{worker="\"management\"",} 5.0
wildfly_xnio_core_worker_pool_size{worker="\"default\"",} 4.0
# HELP wildfly_xnio_max_worker_pool_size MaxWorkerPoolSize (org.xnio<type=Xnio, provider="nio", worker="management"><>MaxWorkerPoolSize)
# TYPE wildfly_xnio_max_worker_pool_size untyped
wildfly_xnio_max_worker_pool_size{worker="\"management\"",} 10.0
wildfly_xnio_max_worker_pool_size{worker="\"default\"",} 64.0
# HELP wildfly_xnio_worker_queue_size WorkerQueueSize (org.xnio<type=Xnio, provider="nio", worker="management"><>WorkerQueueSize)
# TYPE wildfly_xnio_worker_queue_size untyped
wildfly_xnio_worker_queue_size{worker="\"management\"",} 0.0
wildfly_xnio_worker_queue_size{worker="\"default\"",} 0.0
# HELP wildfly_xnio_connection_count ConnectionCount (org.xnio<type=Xnio, provider="nio", worker="management", address="/0.0.0.0:9990"><>ConnectionCount)
# TYPE wildfly_xnio_connection_count untyped
wildfly_xnio_connection_count{worker="\"management\", address=\"/0.0.0.0:9990\"",} -1.0
wildfly_xnio_connection_count{worker="\"default\", address=\"/0.0.0.0:8080\"",} -1.0
wildfly_xnio_connection_count{worker="\"default\", address=\"/0.0.0.0:8443\"",} -1.0
```