### PR TITLE
make test platform-independent

### DIFF
--- a/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/JavaAgentIT.java
+++ b/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/JavaAgentIT.java
@@ -40,7 +40,7 @@ public class JavaAgentIT {
                 continue;
             }
             if (sb.length() != 0) {
-                sb.append(':');
+                sb.append(java.io.File.pathSeparatorChar);
             }
             sb.append(url.getPath());
         }


### PR DESCRIPTION
The original Integration-Test would not work on Windows systems.