### PR TITLE
Enhancements on jmx-exporter

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -57,6 +57,8 @@ public class JmxCollector extends Collector implements Collector.Describable {
       boolean ssl = false;
       boolean lowercaseOutputName;
       boolean lowercaseOutputLabelNames;
+      List<ObjectName> whitelistObjectInstances = new ArrayList<ObjectName>();
+      List<ObjectName> blacklistObjectInstances = new ArrayList<ObjectName>();
       List<ObjectName> whitelistObjectNames = new ArrayList<ObjectName>();
       List<ObjectName> blacklistObjectNames = new ArrayList<ObjectName>();
       ArrayList<Rule> rules = new ArrayList<Rule>();
@@ -142,6 +144,20 @@ public class JmxCollector extends Collector implements Collector.Describable {
 
         if (yamlConfig.containsKey("lowercaseOutputLabelNames")) {
           cfg.lowercaseOutputLabelNames = (Boolean)yamlConfig.get("lowercaseOutputLabelNames");
+        }
+
+        if (yamlConfig.containsKey("whitelistObjectInstances")) {
+            List<Object> names = (List<Object>) yamlConfig.get("whitelistObjectInstances");
+            for(Object name : names) {
+                cfg.whitelistObjectInstances.add(new ObjectName((String)name));
+            }
+        }
+
+        if (yamlConfig.containsKey("blacklistObjectInstances")) {
+            List<Object> names = (List<Object>) yamlConfig.get("blacklistObjectInstances");
+            for(Object name : names) {
+                cfg.blacklistObjectInstances.add(new ObjectName((String)name));
+            }
         }
 
         if (yamlConfig.containsKey("whitelistObjectNames")) {

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -2,6 +2,7 @@ package io.prometheus.jmx;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -68,17 +69,25 @@ public class JmxScraper {
     private String username;
     private String password;
     private boolean ssl;
+    private List<ObjectName> whitelistObjectInstances, blacklistObjectInstances;
     private List<ObjectName> whitelistObjectNames, blacklistObjectNames;
 
     public JmxScraper(String jmxUrl, String username, String password, boolean ssl, List<ObjectName> whitelistObjectNames, List<ObjectName> blacklistObjectNames, MBeanReceiver receiver) {
+        this(jmxUrl, username, password, ssl, Collections.EMPTY_LIST, Collections.EMPTY_LIST, whitelistObjectNames, blacklistObjectNames, receiver);
+    }
+
+    public JmxScraper(String jmxUrl, String username, String password, boolean ssl, List<ObjectName> whitelistObjectInstances, List<ObjectName> blacklistObjectInstances, List<ObjectName> whitelistObjectNames, List<ObjectName> blacklistObjectNames, MBeanReceiver receiver) {
         this.jmxUrl = jmxUrl;
         this.receiver = receiver;
         this.username = username;
         this.password = password;
         this.ssl = ssl;
+        this.whitelistObjectInstances = whitelistObjectInstances;
+        this.blacklistObjectInstances = blacklistObjectInstances;
         this.whitelistObjectNames = whitelistObjectNames;
         this.blacklistObjectNames = blacklistObjectNames;
     }
+
 
     /**
       * Get a list of mbeans on host_port and scrape their values.
@@ -112,8 +121,14 @@ public class JmxScraper {
             for (ObjectName name : whitelistObjectNames) {
                 mBeanNames.addAll(beanConn.queryMBeans(name, null));
             }
+            for (ObjectName name : whitelistObjectInstances) {
+                mBeanNames.add(beanConn.getObjectInstance(name));
+            }
             for (ObjectName name : blacklistObjectNames) {
                 mBeanNames.removeAll(beanConn.queryMBeans(name, null));
+            }
+            for (ObjectName name : blacklistObjectInstances) {
+                mBeanNames.remove(beanConn.getObjectInstance(name));
             }
             for (ObjectInstance name : mBeanNames) {
                 long start = System.nanoTime();


### PR DESCRIPTION
JmxScrape uses queryMBeans as fetching method for MBeans.
It happens that some servers *might* filter some MBeans on queryMBeans, so these MBeans are only accesible via getObjectInstance.
Wildfly has a case for jboss.as:management-root=server MBean which is special and it stores important info for monitoring.
So, a proposal to handle this corner cases is to introduce a new pair of  configuration properties called whitelistObjectInstances/blacklistObjectInstances with the similar use than whitelistObjectNames/blacklistObjectNames but on these cases MBeans are fetched directly (so, no patterns allowed).
On this case, there is backward compatibility with previous behaviour but we can extend these special use cases. 