### PR TITLE
Support for IPv6 bind

### DIFF
--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -13,6 +13,17 @@ public class JavaAgent {
    static HTTPServer server;
 
    public static void premain(String agentArgument, Instrumentation instrumentation) throws Exception {
+     // Bind to all interfaces by default (this includes IPv6).
+     String host = "0.0.0.0";
+
+     // If we have IPv6 address in square brackets, extract it first and then
+     // remove it from arguments to prevent confusion from too namy colons.
+     Integer indexOfClosingSquareBracket = agentArgument.indexOf("]:");
+     if (indexOfClosingSquareBracket >= 0) {
+       host = agentArgument.substring(0, indexOfClosingSquareBracket + 1);
+       agentArgument = agentArgument.substring(indexOfClosingSquareBracket + 2);
+     }
+
      String[] args = agentArgument.split(":");
      if (args.length < 2 || args.length > 3) {
        System.err.println("Usage: -javaagent:/path/to/JavaAgent.jar=[host:]<port>:<yaml configuration file>");
@@ -29,7 +40,7 @@ public class JavaAgent {
        file = args[2];
      } else {
        port = Integer.parseInt(args[0]);
-       socket = new InetSocketAddress(port);
+       socket = new InetSocketAddress(host, port);
        file = args[1];
      }
 


### PR DESCRIPTION
This enables bind to IPv6 address in square brackets:

```
-javaagent:/usr/share/jmx_exporter/agent.jar=[f00::123]:9097:/etc/kafka/jmx-exporter.yaml
```