### PR TITLE
Added Apache ActiveMQ Artemis 2.x example

### DIFF
--- a/example_configs/artemis-2.yml
+++ b/example_configs/artemis-2.yml
@@ -6,20 +6,16 @@ rules:
     attrNameSnakeCase: true
     name: artemis_$2
     type: COUNTER
-    labels:
-        host: $1
   - pattern: "^org.apache.activemq.artemis<broker=\"([^\"]*)\",\\s*component=addresses,\\s*address=\"([^\"]*)\"><>([^:]*):\\s(.*)"
     attrNameSnakeCase: true
     name: artemis_$3
     type: COUNTER
     labels:
-        host: $1
         address: $2
   - pattern: "^org.apache.activemq.artemis<broker=\"([^\"]*)\",\\s*component=addresses,\\s*address=\"([^\"]*)\",\\s*subcomponent=(queue|topic)s,\\s*routing-type=\"([^\"]*)\",\\s*(queue|topic)=\"([^\"]*)\"><>([^: ]*):\\s(.*)"
     attrNameSnakeCase: true
     name: artemis_$7
     type: COUNTER
     labels:
-        host: $1
         address: $2
         "$5": $6

--- a/example_configs/artemis-2.yml
+++ b/example_configs/artemis-2.yml
@@ -1,0 +1,25 @@
+---
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+rules:
+  - pattern: "^org.apache.activemq.artemis<broker=\"([^\"]*)\"><>([^:]*):\\s(.*)"
+    attrNameSnakeCase: true
+    name: artemis_$2
+    type: COUNTER
+    labels:
+        host: $1
+  - pattern: "^org.apache.activemq.artemis<broker=\"([^\"]*)\",\\s*component=addresses,\\s*address=\"([^\"]*)\"><>([^:]*):\\s(.*)"
+    attrNameSnakeCase: true
+    name: artemis_$3
+    type: COUNTER
+    labels:
+        host: $1
+        address: $2
+  - pattern: "^org.apache.activemq.artemis<broker=\"([^\"]*)\",\\s*component=addresses,\\s*address=\"([^\"]*)\",\\s*subcomponent=(queue|topic)s,\\s*routing-type=\"([^\"]*)\",\\s*(queue|topic)=\"([^\"]*)\"><>([^: ]*):\\s(.*)"
+    attrNameSnakeCase: true
+    name: artemis_$7
+    type: COUNTER
+    labels:
+        host: $1
+        address: $2
+        "$5": $6


### PR DESCRIPTION
@brian-brazil I added an example for Apache ActiveMQ Artemis. It only works for version newer than 2 because they changed the JMX MBean object names in this version.

Best regards
Niko