### PR TITLE
Require JDK 6 for compiling and running

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ To bind the java agent to a specific IP change the port number to `host:port`.
 
 See `./run_sample_httpserver.sh` for a sample script that runs the httpserver against itself.
 
+Note: Requires minimum JDK version 1.6
+
 ## Building
 
 `mvn package` to build.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ To bind the java agent to a specific IP change the port number to `host:port`.
 
 See `./run_sample_httpserver.sh` for a sample script that runs the httpserver against itself.
 
-Note: Requires minimum JDK version 1.6
-
 ## Building
 
 `mvn package` to build.

--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -36,16 +36,6 @@
 
   <build>
     <plugins>
-      <!-- Compile version (1.5 for generics) -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-        </configuration>
-      </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>

--- a/jmx_prometheus_httpserver/pom.xml
+++ b/jmx_prometheus_httpserver/pom.xml
@@ -29,17 +29,6 @@
 
   <build>
     <plugins>
-      <!-- Compile version (1.5 for generics) -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-        </configuration>
-      </plugin>
-
       <!-- Build a full jar with dependencies --> 
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -41,17 +41,6 @@
 
   <build>
     <plugins>
-      <!-- Compile version (1.5 for generics) -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-        </configuration>
-      </plugin>
-
       <!-- Build a full shaded jar with dependencies -->
       <plugin>
       <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,15 @@
   <build>
       <plugins>
           <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>2.3.2</version>
+              <configuration>
+                  <source>1.6</source>
+                  <target>1.6</target>
+              </configuration>
+          </plugin>
+          <plugin>
               <artifactId>maven-release-plugin</artifactId>
               <groupId>org.apache.maven.plugins</groupId>
               <version>2.5</version>


### PR DESCRIPTION
Switch to JDK 6 as baseline for all modules.

This fixes the following issues, and simplifies project setup (no JDK baseline mix, project wide Maven compiler plugin configuration):

- The collector module declares JDK 5 target but uses JDK 6 API:
  In collector/src/main/java/io/prometheus/jmx/JmxCollector.java L223, L343, L370, L395 :
  [isEmpty() is JDK 6 String API](https://docs.oracle.com/javase/6/docs/api/java/lang/String.html#isEmpty())

- The collector module also uses simpleclient, which compiles for JDK 6.

- The module jmx_prometheus_httpserver also compiles for JDK 5, but requires collector module. Therefore min version is also JDK 6.

