### PR TITLE
Replace safeName regex to avoid IndexOutOfBoundsException

### DIFF
--- a/collector/src/test/java/io/prometheus/jmx/SafeNameTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/SafeNameTest.java
@@ -1,0 +1,38 @@
+package io.prometheus.jmx;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class SafeNameTest {
+    @Parameterized.Parameters(name = "{index}: testSafeName(expected={0} actual={1}")
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { "test_test", "test-test" }, { "test_test", "test-_test" }, { "test_test", "test-_-test" },
+                { "_", "-_-"}, { "", "" }, { null, null }, { "_", "---" },
+                { "test", "test" },
+                // A very long string
+                { "_asetstjlk_testkljsek_tesktjsekrslk_testkljsetkl_tkesjtk_sljtslkjetesslelse_lktsjetlkesltel_kesjltelksjetkl_tesktjksjltse_sljteslselkselse_tsjetlksetklsjekl_slkfjrtlskek_",
+                "$asetstjlk_$testkljsek_$tesktjsekrslk_$testkljsetkl_$tkesjtk_$sljtslkjetesslelse_$lktsjetlkesltel_$kesjltelksjetkl_$tesktjksjltse_$sljteslselkselse_$tsjetlksetklsjekl_$slkfjrtlskek___" },
+        });
+    }
+
+    private final String expected;
+    private final String input;
+
+    public SafeNameTest(String expected, String input) {
+        this.expected = expected;
+        this.input = input;
+    }
+
+    @Test
+    public void testSafeName() {
+        String safeName = JmxCollector.safeName(input);
+        assertEquals(expected, safeName);
+    }
+}


### PR DESCRIPTION
I'm trying to prevent this exception from ever happening again: 
```
SEVERE: JMX scrape failed: java.lang.IndexOutOfBoundsException: start
31, end 0, s.length() 137
       at java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:539)
       at java.lang.StringBuffer.append(StringBuffer.java:350)
       at java.util.regex.Matcher.appendReplacement(Matcher.java:888)
       at java.util.regex.Matcher.replaceAll(Matcher.java:955)
       at io.prometheus.jmx.shaded.io.prometheus.jmx.JmxCollector$Receiver.recordBean(JmxCollector.java:358)
       at io.prometheus.jmx.shaded.io.prometheus.jmx.JmxScraper.processBeanValue(JmxScraper.java:181)
       at io.prometheus.jmx.shaded.io.prometheus.jmx.JmxScraper.scrapeBean(JmxScraper.java:149)
       at io.prometheus.jmx.shaded.io.prometheus.jmx.JmxScraper.doScrape(JmxScraper.java:110)
       at io.prometheus.jmx.shaded.io.prometheus.jmx.JmxCollector.collect(JmxCollector.java:423)
       at io.prometheus.jmx.shaded.io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.findNextElement(CollectorRegistry.java:180)
       at io.prometheus.jmx.shaded.io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.nextElement(CollectorRegistry.java:213)
       at io.prometheus.jmx.shaded.io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.nextElement(CollectorRegistry.java:134)
       at io.prometheus.jmx.shaded.io.prometheus.client.exporter.common.TextFormat.write004(TextFormat.java:22)
       at io.prometheus.jmx.shaded.io.prometheus.client.exporter.HTTPServer$HTTPMetricHandler.handle(HTTPServer.java:59)
       at com.sun.net.httpserver.Filter$Chain.doFilter(Filter.java:79)
       at sun.net.httpserver.AuthFilter.doFilter(AuthFilter.java:83)
       at com.sun.net.httpserver.Filter$Chain.doFilter(Filter.java:82)
       at sun.net.httpserver.ServerImpl$Exchange$LinkHandler.handle(ServerImpl.java:675)
       at com.sun.net.httpserver.Filter$Chain.doFilter(Filter.java:79)
       at sun.net.httpserver.ServerImpl$Exchange.run(ServerImpl.java:647)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
       at java.lang.Thread.run(Thread.java:748)
```

The root cause in my branch turned out to the `safeName` function. I couldn't write a unit test to reproduce the issue. As a corollary, my implementation sped the function up https://github.com/afalko/testrepo/blob/master/TimingBench2.java: 

```
No regex: StartTime_1_2
156
Original: StartTime_1_2
707
```