### PR TITLE
add bat version of httpserver run script for dev purpose

### DIFF
--- a/run_sample_httpserver.bat
+++ b/run_sample_httpserver.bat
@@ -1,0 +1,5 @@
+@echo off
+:: Script to run a java application for testing jmx4prometheus.
+
+:: Note: You can use localhost:5556 instead of 5556 for configuring socket hostname.
+java -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5555 -jar jmx_prometheus_httpserver/target/jmx_prometheus_httpserver-0.2.1-SNAPSHOT-jar-with-dependencies.jar 5556 example_configs/cassandra.yml


### PR DESCRIPTION
Hi. Think we can add run_sample_httpserver.bat to run standalone extractor on windows environments for development purposes.

@brian-brazil