### PR TITLE
Registering JMX Exporter build info

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/BuildInfoCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/BuildInfoCollector.java
@@ -3,9 +3,10 @@ package io.prometheus.jmx;
 import io.prometheus.client.Collector;
 import io.prometheus.client.GaugeMetricFamily;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
-import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 /**
  * Collects jmx_exporter build version info.
@@ -18,7 +19,7 @@ import static java.util.Collections.singletonList;
  * </pre>
  * Metrics being exported:
  * <pre>
- *   jmx_exporter_build_info{version="3.2.0",} 1.0
+ *   jmx_exporter_build_info{version="3.2.0",name="jmx_prometheus_httpserver",} 1.0
  * </pre>
  */
 public class BuildInfoCollector extends Collector {
@@ -28,11 +29,16 @@ public class BuildInfoCollector extends Collector {
     GaugeMetricFamily artifactInfo = new GaugeMetricFamily(
             "jmx_exporter_build_info",
             "A metric with a constant '1' value labeled with the version of the JMX exporter.",
-            singletonList("version"));
+            asList("version", "name"));
 
-    String version = this.getClass().getPackage().getImplementationVersion();
+    Package pkg = this.getClass().getPackage();
+    String version = pkg.getImplementationVersion();
+    String name = pkg.getImplementationTitle();
 
-    artifactInfo.addMetric(singletonList(version != null ? version : "unknown"), 1L);
+    artifactInfo.addMetric(asList(
+            version != null ? version : "unknown",
+            name != null ? name : "unknown"
+    ), 1L);
     mfs.add(artifactInfo);
 
     return mfs;

--- a/collector/src/main/java/io/prometheus/jmx/BuildInfoCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/BuildInfoCollector.java
@@ -1,0 +1,40 @@
+package io.prometheus.jmx;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.GaugeMetricFamily;
+
+import java.util.*;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * Collects jmx_exporter build version info.
+ * <p>
+ * Example usage:
+ * <pre>
+ * {@code
+ *   new BuildInfoCollector().register();
+ * }
+ * </pre>
+ * Metrics being exported:
+ * <pre>
+ *   jmx_exporter_build_info{version="3.2.0",} 1.0
+ * </pre>
+ */
+public class BuildInfoCollector extends Collector {
+  public List<Collector.MetricFamilySamples> collect() {
+    List<Collector.MetricFamilySamples> mfs = new ArrayList<Collector.MetricFamilySamples>();
+
+    GaugeMetricFamily artifactInfo = new GaugeMetricFamily(
+            "jmx_exporter_build_info",
+            "A metric with a constant '1' value labeled with the version of the JMX exporter.",
+            singletonList("version"));
+
+    String version = this.getClass().getPackage().getImplementationVersion();
+
+    artifactInfo.addMetric(singletonList(version != null ? version : "unknown"), 1L);
+    mfs.add(artifactInfo);
+
+    return mfs;
+  }
+}

--- a/collector/src/test/java/io/prometheus/jmx/BuildInfoCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/BuildInfoCollectorTest.java
@@ -18,12 +18,14 @@ public class BuildInfoCollectorTest {
   @Test
   public void testBuildInfo() {
     String version = this.getClass().getPackage().getImplementationVersion();
+    String name = this.getClass().getPackage().getImplementationTitle();
 
     assertEquals(
             1L,
             registry.getSampleValue(
-                    "jmx_exporter_build_info", new String[]{"version"}, new String[]{
-                            version != null ? version : "unknown"
+                    "jmx_exporter_build_info", new String[]{"version", "name"}, new String[]{
+                            version != null ? version : "unknown",
+                            name != null ? name : "unknown"
                     }),
             .0000001);
   }

--- a/collector/src/test/java/io/prometheus/jmx/BuildInfoCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/BuildInfoCollectorTest.java
@@ -1,0 +1,30 @@
+package io.prometheus.jmx;
+
+import io.prometheus.client.CollectorRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BuildInfoCollectorTest {
+
+  private CollectorRegistry registry = new CollectorRegistry();
+
+  @Before
+  public void setUp() {
+    new BuildInfoCollector().register(registry);
+  }
+
+  @Test
+  public void testBuildInfo() {
+    String version = this.getClass().getPackage().getImplementationVersion();
+
+    assertEquals(
+            1L,
+            registry.getSampleValue(
+                    "jmx_exporter_build_info", new String[]{"version"}, new String[]{
+                            version != null ? version : "unknown"
+                    }),
+            .0000001);
+  }
+}

--- a/jmx_prometheus_httpserver/pom.xml
+++ b/jmx_prometheus_httpserver/pom.xml
@@ -36,6 +36,7 @@
           <archive>
             <manifest>
               <mainClass>io.prometheus.jmx.WebServer</mainClass>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
           </archive>
           <descriptorRefs>

--- a/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
+++ b/jmx_prometheus_httpserver/src/main/java/io/prometheus/jmx/WebServer.java
@@ -26,6 +26,7 @@ public class WebServer {
        socket = new InetSocketAddress(port);
      }
 
+     new BuildInfoCollector().register();
      new JmxCollector(new File(args[1])).register();
      new HTTPServer(socket, CollectorRegistry.defaultRegistry);
    }

--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -83,6 +83,7 @@
              <manifestEntries>
               <Premain-Class>io.prometheus.jmx.shaded.io.prometheus.jmx.JavaAgent</Premain-Class>
               <Implementation-Version>${project.version}</Implementation-Version>
+              <Implementation-Title>${project.artifactId}</Implementation-Title>
              </manifestEntries>
             </transformer>
           </transformers>

--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -82,6 +82,7 @@
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
              <manifestEntries>
               <Premain-Class>io.prometheus.jmx.shaded.io.prometheus.jmx.JavaAgent</Premain-Class>
+              <Implementation-Version>${project.version}</Implementation-Version>
              </manifestEntries>
             </transformer>
           </transformers>

--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -44,6 +44,7 @@ public class JavaAgent {
        file = args[1];
      }
 
+     new BuildInfoCollector().register();
      new JmxCollector(new File(file)).register();
      DefaultExports.initialize();
      server = new HTTPServer(socket, CollectorRegistry.defaultRegistry, true);


### PR DESCRIPTION
By adding the Implementation-Version manifest entry it is possible
to retrieve the lib version at runtime by checking the class Package.

This allows the tracking of which JVMs are running which versions of
the exporter.

Closes #278