### PR TITLE
Make the agent attachable to a running VM

### DIFF
--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -82,6 +82,7 @@
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
              <manifestEntries>
               <Premain-Class>io.prometheus.jmx.shaded.io.prometheus.jmx.JavaAgent</Premain-Class>
+              <Agent-Class>io.prometheus.jmx.shaded.io.prometheus.jmx.JavaAgent</Agent-Class>
               <Implementation-Version>${project.version}</Implementation-Version>
               <Implementation-Title>${project.artifactId}</Implementation-Title>
              </manifestEntries>

--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -12,6 +12,10 @@ public class JavaAgent {
 
    static HTTPServer server;
 
+   public static void agentmain(String agentArgument, Instrumentation instrumentation) throws Exception {
+     premain(agentArgument, instrumentation);
+   }
+
    public static void premain(String agentArgument, Instrumentation instrumentation) throws Exception {
      // Bind to all interfaces by default (this includes IPv6).
      String host = "0.0.0.0";


### PR DESCRIPTION
By adding the agentmain method, we enable the ability of attaching
the JMX Exporter Java Agent to a JVM after the VM starts, providing
a more dynamic approach to managing thousands of deployed VMs.

Usage example:
```
VirtualMachine vm = VirtualMachine.attach(processPID);
vm.loadAgent("./jmx_prometheus_javaagent-0.3.2.jar=8080:config.yaml");
vm.detach();
```

Important to note that this change does not break any of the existing behaviours of the agent nor it adds any extra responsibility to it, it only enables this ability on top of it.

@brian-brazil Can you please review? Could this be something that we could add to the agent?