### PR TITLE
Upgrading compiler target version to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
               <artifactId>maven-compiler-plugin</artifactId>
               <version>2.3.2</version>
               <configuration>
-                  <source>1.6</source>
-                  <target>1.6</target>
+                  <source>1.8</source>
+                  <target>1.8</target>
               </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
The current default target version is 1.6 (parent pom.xml) but
the jmx_exporter does not compile with 1.6. It requires at least
1.7 because of its dependencies.

Upgrading to 1.8 as it is the latest LTS version.

Closes #281 