### PR TITLE
Downgrading maven builder helper plugin to 1.9.1

### DIFF
--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -106,7 +106,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.10</version>
+        <version>1.9.1</version>
         <executions>
           <execution>
             <id>reserve-network-port</id>


### PR DESCRIPTION
This downgrade allows JMX Exporter to keep compatible with Java 6.

The version 1.9.1 of build-helper-maven-plugin is the last version compatible with Java 6.

By accepting this change, issue #281 and PR #282 become not necessary and can be closed as well.