### PR TITLE
Clean up examples

### DIFF
--- a/example_configs/artemis-2.yml
+++ b/example_configs/artemis-2.yml
@@ -4,17 +4,17 @@ lowercaseOutputLabelNames: true
 rules:
   - pattern: "^org.apache.activemq.artemis<broker=\"([^\"]*)\"><>([^:]*):\\s(.*)"
     attrNameSnakeCase: true
-    name: artemis_$2
+    name: "artemis_$2"
     type: COUNTER
   - pattern: "^org.apache.activemq.artemis<broker=\"([^\"]*)\",\\s*component=addresses,\\s*address=\"([^\"]*)\"><>([^:]*):\\s(.*)"
     attrNameSnakeCase: true
-    name: artemis_$3
+    name: "artemis_$3"
     type: COUNTER
     labels:
         address: $2
   - pattern: "^org.apache.activemq.artemis<broker=\"([^\"]*)\",\\s*component=addresses,\\s*address=\"([^\"]*)\",\\s*subcomponent=(queue|topic)s,\\s*routing-type=\"([^\"]*)\",\\s*(queue|topic)=\"([^\"]*)\"><>([^: ]*):\\s(.*)"
     attrNameSnakeCase: true
-    name: artemis_$7
+    name: "artemis_$7"
     type: COUNTER
     labels:
         address: $2

--- a/example_configs/cassandra.yml
+++ b/example_configs/cassandra.yml
@@ -2,13 +2,12 @@
 lowercaseOutputLabelNames: true
 lowercaseOutputName: true
 rules:
-- pattern: org.apache.cassandra.metrics<type=(Connection|Streaming), scope=(\S*), name=(\S*)><>(Count|Value)
-  name: cassandra_$1_$3
+- pattern: "org.apache.cassandra.metrics<type=(Connection|Streaming), scope=(\S*), name=(\S*)><>(Count|Value)"
+  name: "cassandra_$1_$3"
   labels:
     address: "$2"
-- pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?,
-    name=(\S*)><>(Count|Value)
-  name: cassandra_$1_$5
+- pattern: "org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=(\S*)><>(Count|Value)"
+  name: "cassandra_$1_$5"
   labels:
     "$1": "$4"
     "$2": "$3"

--- a/example_configs/flink.yml
+++ b/example_configs/flink.yml
@@ -1,47 +1,47 @@
 rules:
   ## Job Manager ##
   # Example: org.apache.flink.metrics<key0=127.0.0.1, key1=jobmanager, name=taskSlotsTotal><>Value
-  - pattern: org.apache.flink.metrics<key0=(.*), key1=jobmanager, name=([a-z].*)><>Value
-    name: flink_jobmanager_$2
+  - pattern: "org.apache.flink.metrics<key0=(.*), key1=jobmanager, name=([a-z].*)><>Value"
+    name: "flink_jobmanager_$2"
 
   # Example: org.apache.flink.metrics<key0=127.0.0.1, key1=jobmanager, key2=My_Job, name=lastCheckpointDuration><>Value
-  - pattern: org.apache.flink.metrics<key0=(.*), key1=jobmanager, key2=(.*), name=([a-z].*)><>Value
-    name: flink_jobmanager_$3
+  - pattern: "org.apache.flink.metrics<key0=(.*), key1=jobmanager, key2=(.*), name=([a-z].*)><>Value"
+    name: "flink_jobmanager_$3"
     labels:
-      flink_job: $2
+      flink_job: "$2"
 
   ## Task Manager ##
   # Example: org.apache.flink.metrics<key0=debian-8, key1=taskmanager, key2=407401ecfef1f050d3dcc83af9cbfb74, key3=My_Job, key4=Map, key6=1, name=numRecordsIn><>Count
-  - pattern: org.apache.flink.metrics<key0=(.*), key1=taskmanager, key2=(.*), key3=(.*), key4=(.*), key5=([0-9]*), name=([a-z].*)><>Count
-    name: flink_taskmanager_$6_total
+  - pattern: "org.apache.flink.metrics<key0=(.*), key1=taskmanager, key2=(.*), key3=(.*), key4=(.*), key5=([0-9]*), name=([a-z].*)><>Count"
+    name: "flink_taskmanager_$6_total"
     labels:
-      flink_job: $3
-      operator: $4
-      partition: $5
+      flink_job: "$3"
+      operator: "$4"
+      partition: "$5"
     type: COUNTER
 
   # Example: org.apache.flink.metrics<key0=debian-8, key1=taskmanager, key2=407401ecfef1f050d3dcc83af9cbfb74, key3=My_Job, key4=fold_->_sink, key6=0, name=lastCheckpointSize><>Value
-  - pattern: org.apache.flink.metrics<key0=(.*), key1=taskmanager, key2=(.*), key3=(.*), key4=(.*), key5=([0-9]*), name=([a-z].*)><>Value
-    name: flink_taskmanager_$6
+  - pattern: "org.apache.flink.metrics<key0=(.*), key1=taskmanager, key2=(.*), key3=(.*), key4=(.*), key5=([0-9]*), name=([a-z].*)><>Value"
+    name: "flink_taskmanager_$6"
     labels:
-      flink_job: $3
-      operator: $4
-      partition: $5
+      flink_job: "$3"
+      operator: "$4"
+      partition: "$5"
 
   # Example: org.apache.flink.metrics<key0=debian-8, key1=taskmanager, key2=407401ecfef1f050d3dcc83af9cbfb74, key3=My_Job, key4=Sink, key5=1, key6=KafkaProducer, name=batch-size-avg><>Value
-  - pattern: org.apache.flink.metrics<key0=(.*), key1=taskmanager, key2=(.*), key3=(.*), key4=(.*), key5=([0-9]*), key6=KafkaProducer, name=([a-z].*)><>Value
-    name: flink_taskmanager_kafka_producer_$6
+  - pattern: "org.apache.flink.metrics<key0=(.*), key1=taskmanager, key2=(.*), key3=(.*), key4=(.*), key5=([0-9]*), key6=KafkaProducer, name=([a-z].*)><>Value"
+    name: "flink_taskmanager_kafka_producer_$6"
     labels:
-      flink_job: $3
-      operator: $4
-      partition: $5
+      flink_job: "$3"
+      operator: "$4"
+      partition: "$5"
 
   # Example: org.apache.flink.metrics<key0=debian-8, key1=taskmanager, key2=407401ecfef1f050d3dcc83af9cbfb74, key3=My_Job, key4=Source, key5=1, key6=KafkaConsumer, key7=committed-offsets, name=topic-name-1><>Value
-  - pattern: org.apache.flink.metrics<key0=(.*), key1=taskmanager, key2=(.*), key3=(.*), key4=(.*), key5=([0-9]*), key6=KafkaConsumer, key7=(.*), name=([a-z].*)><>Value
-    name: flink_taskmanager_kafka_consumer
+  - pattern: "org.apache.flink.metrics<key0=(.*), key1=taskmanager, key2=(.*), key3=(.*), key4=(.*), key5=([0-9]*), key6=KafkaConsumer, key7=(.*), name=([a-z].*)><>Value"
+    name: "flink_taskmanager_kafka_consumer"
     labels:
-      flink_job: $3
-      operator: $4
-      partition: $5
-      offsets: $6
-      name: $7
+      flink_job: "$3"
+      operator: "$4"
+      partition: "$5"
+      offsets: "$6"
+      name: "$7"

--- a/example_configs/flink.yml
+++ b/example_configs/flink.yml
@@ -1,3 +1,4 @@
+---
 rules:
   ## Job Manager ##
   # Example: org.apache.flink.metrics<key0=127.0.0.1, key1=jobmanager, name=taskSlotsTotal><>Value

--- a/example_configs/kafka-0-8-2.yml
+++ b/example_configs/kafka-0-8-2.yml
@@ -1,90 +1,85 @@
-   
 lowercaseOutputName: true
 rules:
-- pattern : kafka.cluster<type=(.+), name=(.+), topic=(.+), partition=(.+)><>Value
-  name: kafka_cluster_$1_$2
+- pattern : "kafka.cluster<type=(.+), name=(.+), topic=(.+), partition=(.+)><>Value"
+  name: "kafka_cluster_$1_$2"
   labels:
     topic: "$3"
     partition: "$4"
-- pattern : kafka.log<type=Log, name=(.+), topic=(.+), partition=(.+)><>Value
-  name: kafka_log_$1
+- pattern : "kafka.log<type=Log, name=(.+), topic=(.+), partition=(.+)><>Value"
+  name: "kafka_log_$1"
   labels:
     topic: "$2"
     partition: "$3"
-- pattern : kafka.controller<type=(.+), name=(.+)><>(Count|Value)
-  name: kafka_controller_$1_$2
-- pattern : kafka.network<type=(.+), name=(.+)><>Value
-  name: kafka_network_$1_$2
-- pattern : kafka.network<type=(.+), name=(.+)PerSec, request=(.+)><>Count
-  name: kafka_network_$1_$2_total
+- pattern : "kafka.controller<type=(.+), name=(.+)><>(Count|Value)"
+  name: "kafka_controller_$1_$2"
+- pattern : "kafka.network<type=(.+), name=(.+)><>Value"
+  name: "kafka_network_$1_$2"
+- pattern : "kafka.network<type=(.+), name=(.+)PerSec, request=(.+)><>Count"
+  name: "kafka_network_$1_$2_total"
   labels:
     request: "$3"
-- pattern : kafka.network<type=(.+), name=(\w+), networkProcessor=(.+)><>Count
-  name: kafka_network_$1_$2
+- pattern : "kafka.network<type=(.+), name=(\w+), networkProcessor=(.+)><>Count"
+  name: "kafka_network_$1_$2"
   labels:
     request: "$3"
   type: COUNTER
-- pattern : kafka.network<type=(.+), name=(\w+), request=(\w+)><>Count
-  name: kafka_network_$1_$2
+- pattern : "kafka.network<type=(.+), name=(\w+), request=(\w+)><>Count"
+  name: "kafka_network_$1_$2"
   labels:
     request: "$3"
-- pattern : kafka.network<type=(.+), name=(\w+)><>Count
-  name: kafka_network_$1_$2
-- pattern : kafka.server<type=(.+), name=(.+)PerSec\w*, topic=(.+)><>Count
-  name: kafka_server_$1_$2_total
+- pattern : "kafka.network<type=(.+), name=(\w+)><>Count"
+  name: "kafka_network_$1_$2"
+- pattern : "kafka.server<type=(.+), name=(.+)PerSec\w*, topic=(.+)><>Count"
+  name: "kafka_server_$1_$2_total"
   labels:
     topic: "$3"
-- pattern : kafka.server<type=(.+), name=(.+)PerSec\w*><>Count
-  name: kafka_server_$1_$2_total
+- pattern : "kafka.server<type=(.+), name=(.+)PerSec\w*><>Count"
+  name: "kafka_server_$1_$2_total"
   type: COUNTER
-
-- pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>(Count|Value)
-  name: kafka_server_$1_$2
+- pattern : "kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>(Count|Value)"
+  name: "kafka_server_$1_$2"
   labels:
     clientId: "$3"
     topic: "$4"
     partition: "$5"
-- pattern : kafka.server<type=(.+), name=(.+), topic=(.+), partition=(.*)><>(Count|Value)
-  name: kafka_server_$1_$2
+- pattern : "kafka.server<type=(.+), name=(.+), topic=(.+), partition=(.*)><>(Count|Value)"
+  name: "kafka_server_$1_$2"
   labels:
     topic: "$3"
     partition: "$4"
-- pattern : kafka.server<type=(.+), name=(.+), topic=(.+)><>(Count|Value)
-  name: kafka_server_$1_$2
+- pattern : "kafka.server<type=(.+), name=(.+), topic=(.+)><>(Count|Value)"
+  name: "kafka_server_$1_$2"
   labels:
     topic: "$3"
   type: COUNTER
-
-- pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>(Count|Value)
-  name: kafka_server_$1_$2
+- pattern : "kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>(Count|Value)"
+  name: "kafka_server_$1_$2"
   labels:
     clientId: "$3"
     broker: "$4:$5"
-- pattern : kafka.server<type=(.+), name=(.+), clientId=(.+)><>(Count|Value)
-  name: kafka_server_$1_$2
+- pattern : "kafka.server<type=(.+), name=(.+), clientId=(.+)><>(Count|Value)"
+  name: "kafka_server_$1_$2"
   labels:
     clientId: "$3"
-- pattern : kafka.server<type=(.+), name=(.+)><>(Count|Value)
-  name: kafka_server_$1_$2
-
-- pattern : kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count
-  name: kafka_$1_$2_$3_total
-- pattern : kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, topic=(.+)><>Count
-  name: kafka_$1_$2_$3_total
+- pattern : "kafka.server<type=(.+), name=(.+)><>(Count|Value)"
+  name: "kafka_server_$1_$2"
+- pattern : "kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count"
+  name: "kafka_$1_$2_$3_total"
+- pattern : "kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, topic=(.+)><>Count"
+  name: "kafka_$1_$2_$3_total"
   labels:
     topic: "$4"
   type: COUNTER
-- pattern : kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, topic=(.+), partition=(.+)><>Count
-  name: kafka_$1_$2_$3_total
+- pattern : "kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, topic=(.+), partition=(.+)><>Count"
+  name: "kafka_$1_$2_$3_total"
   labels:
     topic: "$4"
     partition: "$5"
   type: COUNTER
-- pattern : kafka.(\w+)<type=(.+), name=(.+)><>(Count|Value)
-  name: kafka_$1_$2_$3_$4
+- pattern : "kafka.(\w+)<type=(.+), name=(.+)><>(Count|Value)"
+  name: "kafka_$1_$2_$3_$4"
   type: COUNTER
-- pattern : kafka.(\w+)<type=(.+), name=(.+), (\w+)=(.+)><>(Count|Value)
-  name: kafka_$1_$2_$3_$6
+- pattern : "kafka.(\w+)<type=(.+), name=(.+), (\w+)=(.+)><>(Count|Value)"
+  name: "kafka_$1_$2_$3_$6"
   labels:
     "$4": "$5"
-

--- a/example_configs/kafka-0-8-2.yml
+++ b/example_configs/kafka-0-8-2.yml
@@ -1,3 +1,4 @@
+---
 lowercaseOutputName: true
 rules:
 - pattern : "kafka.cluster<type=(.+), name=(.+), topic=(.+), partition=(.+)><>Value"

--- a/example_configs/kafka-2_0_0.yml
+++ b/example_configs/kafka-2_0_0.yml
@@ -1,86 +1,86 @@
+---
 lowercaseOutputName: true
-
 rules:
 # Special cases and very specific rules
-- pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
-  name: kafka_server_$1_$2
+- pattern : "kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value"
+  name: "kafka_server_$1_$2"
   type: GAUGE
   labels:
     clientId: "$3"
     topic: "$4"
     partition: "$5"
-- pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
-  name: kafka_server_$1_$2
+- pattern : "kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value"
+  name: "kafka_server_$1_$2"
   type: GAUGE
   labels:
     clientId: "$3"
     broker: "$4:$5"
 
 # Generic per-second counters with 0-2 key/value pairs
-- pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+), (.+)=(.+)><>Count
-  name: kafka_$1_$2_$3_total
+- pattern: "kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+), (.+)=(.+)><>Count"
+  name: "kafka_$1_$2_$3_total"
   type: COUNTER
   labels:
     "$4": "$5"
     "$6": "$7"
-- pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+)><>Count
-  name: kafka_$1_$2_$3_total
+- pattern: "kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+)><>Count"
+  name: "kafka_$1_$2_$3_total"
   type: COUNTER
   labels:
     "$4": "$5"
   type: COUNTER
-- pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count
-  name: kafka_$1_$2_$3_total
+- pattern: "kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count"
+  name: "kafka_$1_$2_$3_total"
   type: COUNTER
 
 # Generic gauges with 0-2 key/value pairs
-- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Value
-  name: kafka_$1_$2_$3
+- pattern: "kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Value"
+  name: "kafka_$1_$2_$3"
   type: GAUGE
   labels:
     "$4": "$5"
     "$6": "$7"
-- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Value
-  name: kafka_$1_$2_$3
+- pattern: "kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Value"
+  name: "kafka_$1_$2_$3"
   type: GAUGE
   labels:
     "$4": "$5"
-- pattern: kafka.(\w+)<type=(.+), name=(.+)><>Value
-  name: kafka_$1_$2_$3
+- pattern: "kafka.(\w+)<type=(.+), name=(.+)><>Value"
+  name: "kafka_$1_$2_$3"
   type: GAUGE
 
 # Emulate Prometheus 'Summary' metrics for the exported 'Histogram's.
 #
 # Note that these are missing the '_sum' metric!
-- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Count
-  name: kafka_$1_$2_$3_count
+- pattern: "kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Count"
+  name: "kafka_$1_$2_$3_count"
   type: COUNTER
   labels:
     "$4": "$5"
     "$6": "$7"
-- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*), (.+)=(.+)><>(\d+)thPercentile
-  name: kafka_$1_$2_$3
+- pattern: "kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*), (.+)=(.+)><>(\d+)thPercentile"
+  name: "kafka_$1_$2_$3"
   type: GAUGE
   labels:
     "$4": "$5"
     "$6": "$7"
     quantile: "0.$8"
-- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Count
-  name: kafka_$1_$2_$3_count
+- pattern: "kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Count"
+  name: "kafka_$1_$2_$3_count"
   type: COUNTER
   labels:
     "$4": "$5"
-- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*)><>(\d+)thPercentile
-  name: kafka_$1_$2_$3
+- pattern: "kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*)><>(\d+)thPercentile"
+  name: "kafka_$1_$2_$3"
   type: GAUGE
   labels:
     "$4": "$5"
     quantile: "0.$6"
-- pattern: kafka.(\w+)<type=(.+), name=(.+)><>Count
-  name: kafka_$1_$2_$3_count
+- pattern: "kafka.(\w+)<type=(.+), name=(.+)><>Count"
+  name: "kafka_$1_$2_$3_count"
   type: COUNTER
-- pattern: kafka.(\w+)<type=(.+), name=(.+)><>(\d+)thPercentile
-  name: kafka_$1_$2_$3
+- pattern: "kafka.(\w+)<type=(.+), name=(.+)><>(\d+)thPercentile"
+  name: "kafka_$1_$2_$3"
   type: GAUGE
   labels:
     quantile: "0.$4"

--- a/example_configs/kafka-pre0-8-2.yml
+++ b/example_configs/kafka-pre0-8-2.yml
@@ -1,59 +1,59 @@
+---
 lowercaseOutputName: true
 rules:
 - pattern: '"kafka.consumer"<type="(.+)", name="ReplicaFetcherThread-(\d+)-\d+-(\w+)"><>(Count)'
-  name: kafka_consumer_$1_$3_$4
+  name: "kafka_consumer_$1_$3_$4"
   labels:
-    thread: $2
+    thread: "$2"
 - pattern: '"kafka.consumer"<type="(.+)", name="ReplicaFetcherThread-(\d+)-\d+-host_(.+?)-port_(\d+)-(\w+)"><>(Count|Value)'
-  name: kafka_consumer_$1_$5_$6
+  name: "kafka_consumer_$1_$5_$6"
   labels:
-    hostport: $3:$4
-    thread: $2
-- name: kafka_consumer_$1_$7_$8
-  pattern: '"kafka.consumer"<type="(.+)", name="ReplicaFetcherThread-(\d+)-\d+-host_(.+?)-port_(\d+)-(.+)-(\d+)-(\w+)"><>(Count|Value)'
+    hostport: "$3:$4"
+    thread: "$2"
+- pattern: '"kafka.consumer"<type="(.+)", name="ReplicaFetcherThread-(\d+)-\d+-host_(.+?)-port_(\d+)-(.+)-(\d+)-(\w+)"><>(Count|Value)'
+  name: kafka_consumer_$1_$7_$8
   labels:
-    hostport: $3:$4
-    partition: $6
-    thread: $2
-    topic: $5
+    hostport: "$3:$4"
+    partition: "$6"
+    thread: "$2"
+    topic: "$5"
 - pattern: '"kafka.server"<type="(FetcherStats)", name="ReplicaFetcherThread-(\d+)-\d+-host_(.+?)-port_(\d+)-(\w+)PerSec"><>Count'
-  name: kafka_server_$1_$5_total
+  name: "kafka_server_$1_$5_total"
   labels:
-    hostport: $3:$4
-    thread: $2
+    hostport: "$3:$4"
+    thread: "$2"
 - pattern: '"kafka.server"<type="(FetcherLag.+)", name="ReplicaFetcherThread-(\d+)-\d+-host_(.+?)-port_(\d+)-(.+)-(\d+)-(\w+)"><>(Count|Value)'
-  name: kafka_server_$1_$7_$8
+  name: "kafka_server_$1_$7_$8"
   labels:
-    hostport: $3:$4
-    partition: $6
-    thread: $2
-    topic: $5
-- name: kafka_cluster_$1_$4
-  pattern: '"kafka.cluster"<type="(.+)", name="(.+)-(\d+)-(\w+)"><>Value'
+    hostport: "$3:$4"
+    partition: "$6"
+    thread: "$2"
+    topic: "$5"
+- pattern: '"kafka.cluster"<type="(.+)", name="(.+)-(\d+)-(\w+)"><>Value'
+  name: "kafka_cluster_$1_$4"
   labels:
-    partition: $3
-    topic: $2
+    partition: "$3"
+    topic: "$2"
 - pattern: '"kafka.log"<type="Log", name="(.+)-(\d+)-(\w+)"><>Value'
-  name: kafka_log_$3
+  name: "kafka_log_$3"
   labels:
-    partition: $2
-    topic: $1
+    partition: "$2"
+    topic: "$1"
 - pattern: '"kafka.server"<type="(.+)", name="(.+)-(\w+)PerSec"><>Count'
-  name: kafka_server_$1_$3_total
+  name: "kafka_server_$1_$3_total"
   labels:
-    topic: $2
+    topic: "$2"
   type: COUNTER
 - pattern: '"kafka.server"<type="(.+)", name="(.+)-(\w+)"><>(Count|Value)'
-  name: kafka_server_$1_$3_$4
+  name: "kafka_server_$1_$3_$4"
   labels:
-    topic: $2
+    topic: "$2"
 - pattern: '"kafka.network"<type="(.+)", name="Processor-(\d+)-(.+)"><>Value'
-  name: kafka_network_$1_$3
+  name: "kafka_network_$1_$3"
   labels:
-    processor: $2
+    processor: "$2"
 - pattern: '"kafka.(\w+)"<type="(.+)", name="(.+)PerSec"><>Count'
-  name: kafka_$1_$2_$3_total
+  name: "kafka_$1_$2_$3_total"
   type: COUNTER
 - pattern: '"kafka.(\w+)"<type="(.+)", name="(.+)"><>(Count|Value)'
-  name: kafka_$1_$2_$3_$4
-
+  name: "kafka_$1_$2_$3_$4"

--- a/example_configs/spark.yml
+++ b/example_configs/spark.yml
@@ -1,26 +1,26 @@
+---
 rules:
-
   # These come from the master
   # Example: master.aliveWorkers
   - pattern: "metrics<name=master\\.(.*)><>Value"
-    name: spark_master_$1
+    name: "spark_master_$1"
 
   # These come from the worker
   # Example: worker.coresFree
   - pattern: "metrics<name=worker\\.(.*)><>Value"
-    name: spark_worker_$1
+    name: "spark_worker_$1"
 
   # These come from the application driver
   # Example: app-20160809000059-0000.driver.DAGScheduler.stage.failedStages
   - pattern: "metrics<name=(.*)\\.driver\\.(DAGScheduler|BlockManager)\\.(.*)><>Value"
-    name: spark_driver_$2_$3
+    name: "spark_driver_$2_$3"
     labels:
       app_id: "$1"
 
   # These come from the application driver if it's a streaming application
   # Example: app-20160809000059-0000.driver.com.example.ClassName.StreamingMetrics.streaming.lastCompletedBatch_schedulingDelay
   - pattern: "metrics<name=(.*)\\.driver\\.(.*)\\.StreamingMetrics\\.streaming\\.(.*)><>Value"
-    name: spark_streaming_driver_$3
+    name: "spark_streaming_driver_$3"
     labels:
       app_id: "$1"
       app_name: "$2"
@@ -28,7 +28,7 @@ rules:
   # These come from the application driver if it's a structured streaming application
   # Example: app-20160809000059-0000.driver.spark.streaming.QueryName.inputRate-total
   - pattern: "metrics<name=(.*)\\.driver\\.spark\\.streaming\\.(.*)\\.(.*)><>Value"
-    name: spark_structured_streaming_driver_$3
+    name: "spark_structured_streaming_driver_$3"
     labels:
       app_id: "$1"
       query_name: "$2"
@@ -36,7 +36,7 @@ rules:
   # These come from the application executors
   # Example: app-20160809000059-0000.0.executor.threadpool.activeTasks
   - pattern: "metrics<name=(.*)\\.(.*)\\.executor\\.(.*)><>Value"
-    name: spark_executor_$3
+    name: "spark_executor_$3"
     labels:
       app_id: "$1"
       executor_id: "$2"
@@ -44,7 +44,7 @@ rules:
   # These come from the master
   # Example: application.com.example.ClassName.1470700859054.cores
   - pattern: "metrics<name=application\\.(.*)\\.([0-9]+)\\.(.*)><>Value"
-    name: spark_application_$3
+    name: "spark_application_$3"
     labels:
       app_name: "$1"
       app_start_epoch: "$2"

--- a/example_configs/tomcat.yml
+++ b/example_configs/tomcat.yml
@@ -3,31 +3,30 @@ lowercaseOutputLabelNames: true
 lowercaseOutputName: true
 rules:
 - pattern: 'Catalina<type=GlobalRequestProcessor, name=\"(\w+-\w+)-(\d+)\"><>(\w+):'
-  name: tomcat_$3_total
+  name: "tomcat_$3_total"
   labels:
     port: "$2"
     protocol: "$1"
-  help: Tomcat global $3
+  help: "Tomcat global $3"
   type: COUNTER
 - pattern: 'Catalina<j2eeType=Servlet, WebModule=//([-a-zA-Z0-9+&@#/%?=~_|!:.,;]*[-a-zA-Z0-9+&@#/%=~_|]), name=([-a-zA-Z0-9+/$%~_-|!.]*), J2EEApplication=none, J2EEServer=none><>(requestCount|maxTime|processingTime|errorCount):'
-  name: tomcat_servlet_$3_total
+  name: "tomcat_servlet_$3_total"
   labels:
     module: "$1"
     servlet: "$2"
-  help: Tomcat servlet $3 total
+  help: "Tomcat servlet $3 total"
   type: COUNTER
 - pattern: 'Catalina<type=ThreadPool, name="(\w+-\w+)-(\d+)"><>(currentThreadCount|currentThreadsBusy|keepAliveCount|pollerThreadCount|connectionCount):'
-  name: tomcat_threadpool_$3
+  name: "tomcat_threadpool_$3"
   labels:
     port: "$2"
     protocol: "$1"
-  help: Tomcat threadpool $3
+  help: "Tomcat threadpool $3"
   type: GAUGE
 - pattern: 'Catalina<type=Manager, host=([-a-zA-Z0-9+&@#/%?=~_|!:.,;]*[-a-zA-Z0-9+&@#/%=~_|]), context=([-a-zA-Z0-9+/$%~_-|!.]*)><>(processingTime|sessionCounter|rejectedSessions|expiredSessions):'
-  name: tomcat_session_$3_total
+  name: "tomcat_session_$3_total"
   labels:
     context: "$2"
     host: "$1"
-  help: Tomcat session $3 total
+  help: "Tomcat session $3 total"
   type: COUNTER
-

--- a/example_configs/weblogic.yml
+++ b/example_configs/weblogic.yml
@@ -24,25 +24,25 @@ whitelistObjectNames:
 rules:
   # ex: com.bea<ServerRuntime=AdminServer, Name=default, ApplicationRuntime=moduleJMS, Type=WorkManagerRuntime><>CompletedRequests
   - pattern: "^com.bea<ServerRuntime=(.+), Name=(.+), (.+)Runtime=(.*), Type=(.+)Runtime><>(.+):"
-    name: weblogic_$3_$5_$6
+    name: "weblogic_$3_$5_$6"
     attrNameSnakeCase: true
     labels:
-      runtime: $1
-      name: $2
-      application: $4
+      runtime: "$1"
+      name: "$2"
+      application: "$4"
 
   # ex: com.bea<ServerRuntime=AdminServer, Name=dsName, Type=JDBCDataSourceRuntime><>Metric
   - pattern: "^com.bea<ServerRuntime=(.+), Name=(.+), Type=(.+)Runtime><>(.+):"
-    name: weblogic_$3_$4
+    name: "weblogic_$3_$4"
     attrNameSnakeCase: true
     labels:
-      runtime: $1
-      name: $2
+      runtime: "$1"
+      name: "$2"
 
   # ex: com.bea<ServerRuntime=AdminServer, Name=bea_wls_cluster_internal, Type=ApplicationRuntime><OverallHealthStateJMX>IsCritical
   - pattern: "^com.bea<ServerRuntime=(.+), Name=(.+), Type=(.+)Runtime><(.+)>(.+):"
-    name: weblogic_$3_$4_$5
+    name: "weblogic_$3_$4_$5"
     attrNameSnakeCase: true
     labels:
-      runtime: $1
-      name: $2
+      runtime: "$1"
+      name: "$2"

--- a/example_configs/wildfly-10.yaml
+++ b/example_configs/wildfly-10.yaml
@@ -15,24 +15,20 @@ whitelistObjectNames:
 rules:
   - pattern: "^jboss.as<subsystem=messaging-activemq, server=.+, jms-(queue|topic)=(.+)><>(.+):"
     attrNameSnakeCase: true
-    name: wildfly_messaging_$3
+    name: "wildfly_messaging_$3"
     labels:
       $1: $2
-
   - pattern: "^jboss.as<subsystem=datasources, (?:xa-)*data-source=(.+), statistics=(.+)><>(.+):"
     attrNameSnakeCase: true
-    name: wildfly_datasource_$2_$3
+    name: "wildfly_datasource_$2_$3"
     labels:
       name: $1
-
   - pattern: "^jboss.as<subsystem=transactions><>number_of_(.+):"
     attrNameSnakeCase: true
-    name: wildfly_transaction_$1
-
+    name: "wildfly_transaction_$1"
   - pattern: "^jboss.as<subsystem=undertow, server=(.+), http-listener=(.+)><>(bytes_.+|error_count|processing_time|request_count):"
     attrNameSnakeCase: true
-    name: wildfly_undertow_$3
+    name: "wildfly_undertow_$3"
     labels:
       server: $1
       http_listener: $2
-

--- a/example_configs/zookeeper.yaml
+++ b/example_configs/zookeeper.yaml
@@ -1,3 +1,4 @@
+---
 rules:
   # replicated Zookeeper
   - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+)><>(\\w+)"
@@ -16,6 +17,7 @@ rules:
     labels:
       replicaId: "$2"
       memberType: "$3"
+
   # standalone Zookeeper
   - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+)><>(\\w+)"
     name: "zookeeper_$2"


### PR DESCRIPTION
Hi Brian,

while testing the exporter with our Zookeeper setup I noticed that the patterns won't match properly if they are not quoted. So I adjusted all examples a bit to include double quotes around the Names, Patterns and Label Values, plus some minor consistency fixes.
Hope this helps somehow.

kind regards,
Phillip Reisbeck