### PR TITLE
Update spark yaml

### DIFF
--- a/example_configs/spark.yml
+++ b/example_configs/spark.yml
@@ -12,15 +12,54 @@ rules:
 
   # These come from the application driver
   # Example: app-20160809000059-0000.driver.DAGScheduler.stage.failedStages
-  - pattern: "metrics<name=(.*)\\.driver\\.(DAGScheduler|BlockManager)\\.(.*)><>Value"
+  - pattern: "metrics<name=(.*)\\.driver\\.(DAGScheduler|BlockManager|jvm)\\.(.*)><>Value"
     name: spark_driver_$2_$3
+    type: GAUGE
+    labels:
+      app_id: "$1"
+
+  # These come from the application driver
+  # Emulate timers for DAGScheduler like messagePRocessingTime
+  - pattern: "metrics<name=(.*)\\.driver\\.DAGScheduler\\.(.*)><>Count"
+    name: spark_driver_DAGScheduler_$2_count
+    type: COUNTER
+    labels:
+      app_id: "$1"
+
+  # HiveExternalCatalog is of type counter
+  - pattern: "metrics<name=(.*)\\.driver\\.HiveExternalCatalog\\.(.*)><>Count"
+    name: spark_driver_HiveExternalCatalog_$2_total
+    type: COUNTER
+    labels:
+      app_id: "$1"
+
+  # These come from the application driver
+  # Emulate histograms for CodeGenerator
+  - pattern: "metrics<name=(.*)\\.driver\\.CodeGenerator\\.(.*)><>Count"
+    name: spark_driver_CodeGenerator_$2_count
+    type: COUNTER
+    labels:
+      app_id: "$1"
+
+  # These come from the application driver
+  # Emulate timer (keep only count attribute) plus counters for LiveListenerBus
+  - pattern: "metrics<name=(.*)\\.driver\\.LiveListenerBus\\.(.*)><>Count"
+    name: spark_driver_LiveListenerBus_$2_count
+    type: COUNTER
+    labels:
+      app_id: "$1"
+
+  # Get Gauge type metrics for LiveListenerBus
+  - pattern: "metrics<name=(.*)\\.driver\\.LiveListenerBus\\.(.*)><>Value"
+    name: spark_driver_LiveListenerBus_$2
+    type: GAUGE
     labels:
       app_id: "$1"
 
   # These come from the application driver if it's a streaming application
   # Example: app-20160809000059-0000.driver.com.example.ClassName.StreamingMetrics.streaming.lastCompletedBatch_schedulingDelay
   - pattern: "metrics<name=(.*)\\.driver\\.(.*)\\.StreamingMetrics\\.streaming\\.(.*)><>Value"
-    name: spark_streaming_driver_$3
+    name: spark_driver_streaming_$3
     labels:
       app_id: "$1"
       app_name: "$2"
@@ -28,23 +67,50 @@ rules:
   # These come from the application driver if it's a structured streaming application
   # Example: app-20160809000059-0000.driver.spark.streaming.QueryName.inputRate-total
   - pattern: "metrics<name=(.*)\\.driver\\.spark\\.streaming\\.(.*)\\.(.*)><>Value"
-    name: spark_structured_streaming_driver_$3
+    name: spark_driver_structured_streaming_$3
     labels:
       app_id: "$1"
       query_name: "$2"
 
   # These come from the application executors
-  # Example: app-20160809000059-0000.0.executor.threadpool.activeTasks
+  # Example: app-20160809000059-0000.0.executor.threadpool.activeTasks (value)
+  #  app-20160809000059-0000.0.executor.JvmGCtime (counter)
   - pattern: "metrics<name=(.*)\\.(.*)\\.executor\\.(.*)><>Value"
     name: spark_executor_$3
+    type: GAUGE
     labels:
       app_id: "$1"
       executor_id: "$2"
 
-  # These come from the master
-  # Example: application.com.example.ClassName.1470700859054.cores
-  - pattern: "metrics<name=application\\.(.*)\\.([0-9]+)\\.(.*)><>Value"
-    name: spark_application_$3
+  # Executors counters
+  - pattern: "metrics<name=(.*)\\.(.*)\\.executor\\.(.*)><>Count"
+    name: spark_executor_$3_total
+    type: COUNTER
     labels:
-      app_name: "$1"
-      app_start_epoch: "$2"
+      app_id: "$1"
+      executor_id: "$2"
+
+  # These come from the application executors
+  # Example: app-20160809000059-0000.0.jvm.threadpool.activeTasks
+  - pattern: "metrics<name=(.*)\\.([0-9]+)\\.(jvm|NettyBlockTransfer)\\.(.*)><>Value"
+    name: spark_executor_$3_$4
+    type: GAUGE
+    labels:
+      app_id: "$1"
+      executor_id: "$2"
+
+  - pattern: "metrics<name=(.*)\\.([0-9]+)\\.HiveExternalCatalog\\.(.*)><>Count"
+    name: spark_executor_HiveExternalCatalog_$3_count
+    type: COUNTER
+    labels:
+      app_id: "$1"
+      executor_id: "$2"
+
+  # These come from the application driver
+  # Emulate histograms for CodeGenerator
+  - pattern: "metrics<name=(.*)\\.([0-9]+)\\.CodeGenerator\\.(.*)><>Count"
+    name: spark_executor_CodeGenerator_$3_count
+    type: COUNTER
+    labels:
+      app_id: "$1"
+      executor_id: "$2"


### PR DESCRIPTION
- Updates spark example supporting histograms and timers.
- Also covers jvm metrics previously ignored.
Some examples follow of the available metrics exposed by driver/executors and need coverage:

![executor1](https://user-images.githubusercontent.com/7945591/45146265-31654d00-b1cb-11e8-9fdc-d3268ca2e51d.png)
![driver1](https://user-images.githubusercontent.com/7945591/45146266-31654d00-b1cb-11e8-8f79-ca8a313740d3.png)

Also here are some properties that are either a timer or a histogram:
![timer](https://user-images.githubusercontent.com/7945591/45146299-44781d00-b1cb-11e8-9c42-7a1de1a02a33.png)
![histogram](https://user-images.githubusercontent.com/7945591/45146300-44781d00-b1cb-11e8-878f-066f6e163833.png)
I tested this by verifying all metrics are captured using Spark on K8s.
