### PR TITLE
Update the Apache Cassandra example configuration

### DIFF
--- a/example_configs/cassandra.yml
+++ b/example_configs/cassandra.yml
@@ -5,81 +5,54 @@ whitelistObjectNames: ["org.apache.cassandra.metrics:*"]
 blacklistObjectNames: ["org.apache.cassandra.metrics:type=ColumnFamily,*"]
 rules:
 # Generic gauges with 0-2 labels
-- pattern: org.apache.cassandra.metrics<type=(.+), (.+)=(.+), (.+)=(.+), name=(.+)><>Value
-  name: cassandra_$1_$6
+- pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=(\S*)><>Value
+  name: cassandra_$1_$5
   type: GAUGE
   labels:
+    "$1": "$4"
     "$2": "$3"
-    "$4": "$5"
-- pattern: org.apache.cassandra.metrics<type=(.+), (.+)=(.+), name=(.+)><>Value
-  name: cassandra_$1_$4
-  type: GAUGE
-  labels:
-    "$2": "$3"
-- pattern: org.apache.cassandra.metrics<type=(.+), name=(.+)><>Value
-  name: cassandra_$1_$2
-  type: GAUGE
 
 #
 # Emulate Prometheus 'Summary' metrics for the exported 'Histogram's.
 # TotalLatency is the sum of all latencies since server start
 #
-- pattern: org.apache.cassandra.metrics<type=(.+), (.+)=(.+), (.+)=(.+), name=(.+)?(?:Total)(Latency)><>Count
-  name: cassandra_$1_$6$7_sum
+- pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=(.+)?(?:Total)(Latency)><>Count
+  name: cassandra_$1_$5$6_seconds_sum
   type: COUNTER
   labels:
+    "$1": "$4"
     "$2": "$3"
-    "$4": "$5"
-
-- pattern: org.apache.cassandra.metrics<type=(.+), (.+)=(.+), (.+)=(.+), name=(.+)><>Count
-  name: cassandra_$1_$6_count
-  type: COUNTER
-  labels:
-    "$2": "$3"
-    "$4": "$5"
-- pattern: org.apache.cassandra.metrics<type=(.+), (.+)=(.+), (.+)=(.+), name=(.+)><>(\d+)thPercentile
-  name: cassandra_$1_$6_seconds
-  type: GAUGE
-  labels:
-    "$2": "$3"
-    "$4": "$5"
-    quantile: "0.$7"
   # Convert microseconds to seconds
   valueFactor: 0.000001
 
-- pattern: org.apache.cassandra.metrics<type=(.+), (.+)=(.+), name=(.+)?(?:Total)(Latency)><>Count
-  name: cassandra_$1_$4$5_sum
+- pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=((?:.+)?(?:Latency))><>Count
+  name: cassandra_$1_$5_seconds_count
   type: COUNTER
   labels:
+    "$1": "$4"
     "$2": "$3"
 
-- pattern: org.apache.cassandra.metrics<type=(.+), (.+)=(.+), name=(.+)><>Count
-  name: cassandra_$1_$4_count
+- pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=(.+)><>Count
+  name: cassandra_$1_$5_count
   type: COUNTER
   labels:
+    "$1": "$4"
     "$2": "$3"
 
-- pattern: org.apache.cassandra.metrics<type=(.+), (.+)=(.+), name=(.+)><>(\d+)thPercentile
-  name: cassandra_$1_$4_seconds
+- pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=((?:.+)?(?:Latency))><>(\d+)thPercentile
+  name: cassandra_$1_$5_seconds
   type: GAUGE
   labels:
+    "$1": "$4"
     "$2": "$3"
-    quantile: "0.$5"
+    quantile: "0.$6"
   # Convert microseconds to seconds
   valueFactor: 0.000001
 
-- pattern: org.apache.cassandra.metrics<type=(.+), name=(.+)?(?:Total)(Latency)><>Count
-  name: cassandra_$1_$2$3_sum
-  type: COUNTER
-
-- pattern: org.apache.cassandra.metrics<type=(.+), name=(.+)><>Count
-  name: cassandra_$1_$2_count
-  type: COUNTER
-
-- pattern: org.apache.cassandra.metrics<type=(.+), name=(.+)><>(\d+)thPercentile
-  name: cassandra_$1_$2_seconds
+- pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=(.+)><>(\d+)thPercentile
+  name: cassandra_$1_$5
   type: GAUGE
   labels:
-    quantile: "0.$3"
-  # Convert microseconds to seconds
-  valueFactor: 0.000001
+    "$1": "$4"
+    "$2": "$3"
+    quantile: "0.$6"

--- a/example_configs/cassandra.yml
+++ b/example_configs/cassandra.yml
@@ -1,14 +1,85 @@
----
 lowercaseOutputLabelNames: true
 lowercaseOutputName: true
+whitelistObjectNames: ["org.apache.cassandra.metrics:*"]
+# ColumnFamily is an alias for Table metrics
+blacklistObjectNames: ["org.apache.cassandra.metrics:type=ColumnFamily,*"]
 rules:
-- pattern: org.apache.cassandra.metrics<type=(Connection|Streaming), scope=(\S*), name=(\S*)><>(Count|Value)
-  name: cassandra_$1_$3
+# Generic gauges with 0-2 labels
+- pattern: org.apache.cassandra.metrics<type=(.+), (.+)=(.+), (.+)=(.+), name=(.+)><>Value
+  name: cassandra_$1_$6
+  type: GAUGE
   labels:
-    address: "$2"
-- pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?,
-    name=(\S*)><>(Count|Value)
-  name: cassandra_$1_$5
-  labels:
-    "$1": "$4"
     "$2": "$3"
+    "$4": "$5"
+- pattern: org.apache.cassandra.metrics<type=(.+), (.+)=(.+), name=(.+)><>Value
+  name: cassandra_$1_$4
+  type: GAUGE
+  labels:
+    "$2": "$3"
+- pattern: org.apache.cassandra.metrics<type=(.+), name=(.+)><>Value
+  name: cassandra_$1_$2
+  type: GAUGE
+
+#
+# Emulate Prometheus 'Summary' metrics for the exported 'Histogram's.
+# TotalLatency is the sum of all latencies since server start
+#
+- pattern: org.apache.cassandra.metrics<type=(.+), (.+)=(.+), (.+)=(.+), name=(.+)?(?:Total)(Latency)><>Count
+  name: cassandra_$1_$6$7_sum
+  type: COUNTER
+  labels:
+    "$2": "$3"
+    "$4": "$5"
+
+- pattern: org.apache.cassandra.metrics<type=(.+), (.+)=(.+), (.+)=(.+), name=(.+)><>Count
+  name: cassandra_$1_$6_count
+  type: COUNTER
+  labels:
+    "$2": "$3"
+    "$4": "$5"
+- pattern: org.apache.cassandra.metrics<type=(.+), (.+)=(.+), (.+)=(.+), name=(.+)><>(\d+)thPercentile
+  name: cassandra_$1_$6_seconds
+  type: GAUGE
+  labels:
+    "$2": "$3"
+    "$4": "$5"
+    quantile: "0.$7"
+  # Convert microseconds to seconds
+  valueFactor: 0.000001
+
+- pattern: org.apache.cassandra.metrics<type=(.+), (.+)=(.+), name=(.+)?(?:Total)(Latency)><>Count
+  name: cassandra_$1_$4$5_sum
+  type: COUNTER
+  labels:
+    "$2": "$3"
+
+- pattern: org.apache.cassandra.metrics<type=(.+), (.+)=(.+), name=(.+)><>Count
+  name: cassandra_$1_$4_count
+  type: COUNTER
+  labels:
+    "$2": "$3"
+
+- pattern: org.apache.cassandra.metrics<type=(.+), (.+)=(.+), name=(.+)><>(\d+)thPercentile
+  name: cassandra_$1_$4_seconds
+  type: GAUGE
+  labels:
+    "$2": "$3"
+    quantile: "0.$5"
+  # Convert microseconds to seconds
+  valueFactor: 0.000001
+
+- pattern: org.apache.cassandra.metrics<type=(.+), name=(.+)?(?:Total)(Latency)><>Count
+  name: cassandra_$1_$2$3_sum
+  type: COUNTER
+
+- pattern: org.apache.cassandra.metrics<type=(.+), name=(.+)><>Count
+  name: cassandra_$1_$2_count
+  type: COUNTER
+
+- pattern: org.apache.cassandra.metrics<type=(.+), name=(.+)><>(\d+)thPercentile
+  name: cassandra_$1_$2_seconds
+  type: GAUGE
+  labels:
+    quantile: "0.$3"
+  # Convert microseconds to seconds
+  valueFactor: 0.000001

--- a/example_configs/cassandra.yml
+++ b/example_configs/cassandra.yml
@@ -18,7 +18,7 @@ rules:
 #
 - pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=(.+)?(?:Total)(Latency)><>Count
   name: cassandra_$1_$5$6_seconds_sum
-  type: COUNTER
+  type: UNTYPED
   labels:
     "$1": "$4"
     "$2": "$3"
@@ -27,14 +27,14 @@ rules:
 
 - pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=((?:.+)?(?:Latency))><>Count
   name: cassandra_$1_$5_seconds_count
-  type: COUNTER
+  type: UNTYPED
   labels:
     "$1": "$4"
     "$2": "$3"
 
 - pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=(.+)><>Count
   name: cassandra_$1_$5_count
-  type: COUNTER
+  type: UNTYPED
   labels:
     "$1": "$4"
     "$2": "$3"


### PR DESCRIPTION
@brian-brazil 

Inspired by the kafka-2_0_0.yml configuration
* Latency histograms are exported as emulated Summaries.
* Otherwise, histograms exported as Summaries without the _sum.

List of example metrics: [cassandra-example-metrics.txt](https://github.com/prometheus/jmx_exporter/files/2516302/cassandra-example-metrics.txt)

There a ***lot*** of metrics exposed by default. In our implementation, we utilize several whitelistObjectNames values to only capture the specific metrics that we need. Otherwise, it presents a fairly heavy load on the exporter. I didn't want to restrict that outright. Instead, let the users determine which metrics they want to see.