### PR TITLE
fix objectName pattern for messaging queues

### DIFF
--- a/example_configs/wildfly-10.yaml
+++ b/example_configs/wildfly-10.yaml
@@ -6,11 +6,13 @@ whitelistObjectNames:
  # see https://github.com/prometheus/jmx_exporter/issues/246#issuecomment-367573931
  # Each object in the rules below has to be added to whitelistObjectNames too !
  # note that rules use regex (like "foo.*", whereas the whitelist use globbing expressions (like "foo*")
- - "jboss.as:subsystem=messaging-activemq,server=*"
+ - "jboss.as:subsystem=messaging-activemq,server=*,jms-queue=*"
+ - "jboss.as:subsystem=messaging-activemq,server=*,jms-topic=*"
  - "jboss.as:subsystem=datasources,data-source=*,statistics=*"
  - "jboss.as:subsystem=datasources,xa-data-source=*,statistics=*"
  - "jboss.as:subsystem=transactions*"
  - "jboss.as:subsystem=undertow,server=*,http-listener=*"
+ - "jboss.as:subsystem=undertow,server=*,https-listener=*"
  # - "java.lang:*"
 rules:
   - pattern: "^jboss.as<subsystem=messaging-activemq, server=.+, jms-(queue|topic)=(.+)><>(.+):"
@@ -29,10 +31,9 @@ rules:
     attrNameSnakeCase: true
     name: wildfly_transaction_$1
 
-  - pattern: "^jboss.as<subsystem=undertow, server=(.+), http-listener=(.+)><>(bytes_.+|error_count|processing_time|request_count):"
+  - pattern: "^jboss.as<subsystem=undertow, server=(.+), (http[s]?-listener)=(.+)><>(bytes_.+|error_count|processing_time|request_count):"
     attrNameSnakeCase: true
-    name: wildfly_undertow_$3
+    name: wildfly_undertow_$4
     labels:
       server: $1
-      http_listener: $2
-
+      listener: $3


### PR DESCRIPTION
Without this fix only exact "jboss.as:subsystem=messaging-activemq,server=*" objects were found, all having one more identifier (like jms-queue or jms-topic) were not found.
@brian-brazil please, take a look (I'm tagging you according to the process described in Contributing file for trivial fixes)

I've checked this fix on Java8 + WildFly13