### PR TITLE
Stricter safename

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -253,7 +253,7 @@ public class JmxCollector extends Collector implements Collector.Describable {
         safeNameBuilder.append("_");
       }
       for (char nameChar : name.toCharArray()) {
-        boolean isUnsafeChar = !(Character.isLetterOrDigit(nameChar) || nameChar == ':' || nameChar == '_');
+        boolean isUnsafeChar = !JmxCollector.isLegalCharacter(nameChar);
         if ((isUnsafeChar || nameChar == '_')) {
           if (prevCharIsUnderscore) {
             continue;
@@ -269,6 +269,14 @@ public class JmxCollector extends Collector implements Collector.Describable {
 
       return safeNameBuilder.toString();
     }
+
+  private static boolean isLegalCharacter(char input) {
+    return ((input == ':') ||
+            (input == '_') ||
+            (input >= 'a' && input <= 'z') ||
+            (input >= 'A' && input <= 'Z') ||
+            (input >= '0' && input <= '9'));
+  }
 
     class Receiver implements JmxScraper.MBeanReceiver {
       Map<String, MetricFamilySamples> metricFamilySamplesMap =

--- a/collector/src/test/java/io/prometheus/jmx/SafeNameTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/SafeNameTest.java
@@ -20,6 +20,9 @@ public class SafeNameTest {
                 // A very long string
                 { "_asetstjlk_testkljsek_tesktjsekrslk_testkljsetkl_tkesjtk_sljtslkjetesslelse_lktsjetlkesltel_kesjltelksjetkl_tesktjksjltse_sljteslselkselse_tsjetlksetklsjekl_slkfjrtlskek_",
                 "$asetstjlk_$testkljsek_$tesktjsekrslk_$testkljsetkl_$tkesjtk_$sljtslkjetesslelse_$lktsjetlkesltel_$kesjltelksjetkl_$tesktjksjltse_$sljteslselkselse_$tsjetlksetklsjekl_$slkfjrtlskek___" },
+                { "test_swedish_chars_", "test_swedish_chars_åäö" },
+                { "test_test", "test@test" },
+                { "test_test", "test;test" },
         });
     }
 

--- a/collector/src/test/java/io/prometheus/jmx/SafeNameTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/SafeNameTest.java
@@ -23,6 +23,7 @@ public class SafeNameTest {
                 { "test_swedish_chars_", "test_swedish_chars_åäö" },
                 { "test_test", "test@test" },
                 { "test_test", "test;test" },
+                { "test:test", "test:test" },
         });
     }
 


### PR DESCRIPTION
Only characters `a-zA-Z0-9_:` is allowed for names and labels.

The current use of `Character.isLetterOrDigit` supports Unicode characters (within the Basic Multilingual Plane) which lets names using invalid characters through (e.g. use of Swedish letters åäö).

I find this change trivial one, so according to `CONTRIBUTING.md` I went straight ahead and made a pull request. @brian-brazil please review.