### PR TITLE
Add jmxremote_optional dependency into collector to support to scrap remote JMX server metrics

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -31,6 +31,13 @@
       <artifactId>snakeyaml</artifactId>
       <version>1.16</version>
     </dependency>
+    <!-- Since javax.management:jmxremote_optional:1.0.1_04 jar file does not
+         exist on maven central, use substitute one -->
+    <dependency>
+        <groupId>org.glassfish.external</groupId>
+        <artifactId>opendmk_jmxremote_optional_jar</artifactId>
+        <version>1.0-b01-ea</version>
+    </dependency>
   </dependencies>
 
 


### PR DESCRIPTION
Motivation:
- When using <= JDK 8, we can scrap the JMX metrics via JMXMP protocol
  with installing jmxremote_optional.jar to JRE lib/ext dir (that is
  used for JVM extension mechanism).
- But for JDK 10+, this JVM extension mechanism is removed. So we cannot
  support JMXMP protocol anymore

Changes:
- Add jmxremote_optional dependency to collector module

Result:
- Can support JMXMP protocol again