### PR TITLE
include error message with exception

### DIFF
--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -31,7 +31,7 @@ public class JavaAgent {
             server = new HTTPServer(config.socket, CollectorRegistry.defaultRegistry, true);
         }
         catch (IllegalArgumentException e) {
-            System.err.println("Usage: -javaagent:/path/to/JavaAgent.jar=[host:]<port>:<yaml configuration file>");
+            System.err.println("Usage: -javaagent:/path/to/JavaAgent.jar=[host:]<port>:<yaml configuration file> " + e.getMessage());
             System.exit(1);
         }
     }


### PR DESCRIPTION
When the agent starts up, you get the same output no matter what is wrong:

```
Usage: -javaagent:/path/to/JavaAgent.jar=[host:]<port>:<yaml configuration file>```
```

This patch adds the exception to the output:

```
Usage: -javaagent:/path/to/JavaAgent.jar=[host:]<port>:<yaml configuration file> At most one of hostPort and jmxUrl must be provided
```

cc @brian-brazil, 