### PR TITLE
Update simpleclient_hotspot version (#400)

### DIFF
--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_hotspot</artifactId>
-      <version>0.3.0</version>
+      <version>0.6.0</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>

--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -31,7 +31,7 @@ public class JavaAgent {
             server = new HTTPServer(config.socket, CollectorRegistry.defaultRegistry, true);
         }
         catch (IllegalArgumentException e) {
-            System.err.println("Usage: -javaagent:/path/to/JavaAgent.jar=[host:]<port>:<yaml configuration file>");
+            System.err.println("Usage: -javaagent:/path/to/JavaAgent.jar=[host:]<port>:<yaml configuration file> " + e.getMessage());
             System.exit(1);
         }
     }


### PR DESCRIPTION
Hi @brian-brazil 

There is an item I want to see, but it isn't there. (e.g, jvm_threads_state)
I found the simpleclient_hotspot version is too low to see in javaagent.
