### PR TITLE
Clarify how to use JmxScraper standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ If a given part isn't set, it'll be excluded.
 
 ## Debugging
 
-You can start the jmx's scraper in standalone mode in order to debug what is called 
+You can start the jmx's scraper in standalone mode (after building the packages with Maven) in order to debug what is called 
 
-`java -cp jmx_exporter.jar io.prometheus.jmx.shaded.io.prometheus.jmx.JmxScraper  service:jmx:rmi:your_url`
+`java -cp jmx_exporter/collector/target/collector*.jar  io.prometheus.jmx.JmxScraper  service:jmx:rmi:your_url`
 
 To get finer logs (including the duration of each jmx call),
 create a file called logging.properties with this content:

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ If a given part isn't set, it'll be excluded.
 
 You can start the jmx's scraper in standalone mode in order to debug what is called 
 
-`java -cp jmx_exporter.jar io.prometheus.jmx.JmxScraper  service:jmx:rmi:your_url`
+`java -cp jmx_exporter.jar io.prometheus.jmx.shaded.io.prometheus.jmx.JmxScraper  service:jmx:rmi:your_url`
 
 To get finer logs (including the duration of each jmx call),
 create a file called logging.properties with this content:

--- a/README.md
+++ b/README.md
@@ -112,9 +112,14 @@ If a given part isn't set, it'll be excluded.
 
 ## Debugging
 
-You can start the jmx's scraper in standalone mode (after building the packages with Maven) in order to debug what is called 
+You can start the jmx's scraper in standalone mode in order to debug what is called 
 
-`java -cp jmx_exporter/collector/target/collector*.jar  io.prometheus.jmx.JmxScraper  service:jmx:rmi:your_url`
+```
+git clone https://github.com/prometheus/jmx_exporter.git
+cd jmx_exporter
+mvn package
+java -cp collector/target/collector*.jar  io.prometheus.jmx.JmxScraper  service:jmx:rmi:your_url
+```
 
 To get finer logs (including the duration of each jmx call),
 create a file called logging.properties with this content:


### PR DESCRIPTION
With the 0.12.0 jar, you have to use the full shaded package path to run JmxScraper standalone. 