### PR TITLE
Update example Kafka config to omit per-partition metrics

### DIFF
--- a/example_configs/kafka-2_0_0.yml
+++ b/example_configs/kafka-2_0_0.yml
@@ -1,5 +1,20 @@
 lowercaseOutputName: true
 
+# By default, omit certain Kafka metrics that are tagged by topic and by partition.
+# As new topics/partitions are created, these metrics grow exponentially, with Ntopics * Npartitions entries for each of these items.
+# In non-trivial clusters, generating these metrics can effectively result in prometheus timing out the request and dropping the entire payload.
+blacklistObjectNames:
+  - "kafka.cluster:name=InSyncReplicasCount,*"
+  - "kafka.cluster:name=LastStableOffsetLag,*"
+  - "kafka.cluster:name=ReplicasCount,*"
+  - "kafka.cluster:name=UnderMinIsr,*"
+  - "kafka.cluster:name=UnderReplicated,*"
+  - "kafka.log:name=LogEndOffset,*"
+  - "kafka.log:name=LogStartOffset,*"
+  - "kafka.log:name=NumLogSegments,*"
+  - "kafka.log:name=Size,*"
+  - "kafka.server:name=ConsumerLag,*"
+
 rules:
 # Special cases and very specific rules
 - pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value


### PR DESCRIPTION
Per the comment in the change, these metrics scale with Ntopics * Npartitions. In a non-trivial cluster this will lead to payloads getting dropped because they take so long to generate/collect. Therefore it makes sense to omit them as a default unless they're specifically needed.

Tested against Kafka 2.1.

@brian-brazil 