### PR TITLE
Add metrics quota kafka for client-id or/and user

### DIFF
--- a/example_configs/kafka-2_0_0.yml
+++ b/example_configs/kafka-2_0_0.yml
@@ -39,14 +39,14 @@ rules:
   name: kafka_server_quota_$3
   type: GAUGE
   labels:
-    type: "$1"
+    resource: "$1"
     clientId: "$2"
 
 - pattern: kafka.server<type=(.+), user=(.+), client-id=(.+)><>([a-z-]+)
   name: kafka_server_quota_$4
   type: GAUGE
   labels:
-    type: "$1"
+    resource: "$1"
     user: "$2"
     clientId: "$3"
 

--- a/example_configs/kafka-2_0_0.yml
+++ b/example_configs/kafka-2_0_0.yml
@@ -35,6 +35,19 @@ rules:
   name: kafka_$1_$2_$3_total
   type: COUNTER
 
+- pattern: kafka.server<type=(.+), client-id=(.+)><>([^:]+)
+  name: kafka_server_$1_$3
+  type: GAUGE
+  labels:
+    clientId: "$2"
+
+- pattern: kafka.server<type=(.+), user=(.+), client-id=(.+)><>([^:]+)
+  name: kafka_server_$1_$4
+  type: GAUGE
+  labels:
+    user: "$2"
+    clientId: "$3"
+
 # Generic gauges with 0-2 key/value pairs
 - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Value
   name: kafka_$1_$2_$3

--- a/example_configs/kafka-2_0_0.yml
+++ b/example_configs/kafka-2_0_0.yml
@@ -35,16 +35,18 @@ rules:
   name: kafka_$1_$2_$3_total
   type: COUNTER
 
-- pattern: kafka.server<type=(.+), client-id=(.+)><>([^:]+)
-  name: kafka_server_$1_$3
+- pattern: kafka.server<type=(.+), client-id=(.+)><>([a-z-]+)
+  name: kafka_server_quota_$3
   type: GAUGE
   labels:
+    type: "$1"
     clientId: "$2"
 
-- pattern: kafka.server<type=(.+), user=(.+), client-id=(.+)><>([^:]+)
-  name: kafka_server_$1_$4
+- pattern: kafka.server<type=(.+), user=(.+), client-id=(.+)><>([a-z-]+)
+  name: kafka_server_quota_$4
   type: GAUGE
   labels:
+    type: "$1"
     user: "$2"
     clientId: "$3"
 


### PR DESCRIPTION
@brian-brazil adding metrics for quotas of client-id and/or user for Apache Kafka config exemples. This patter alredy is working in my environment. However this is metrics only appears when the quotas they are enebled. 

Link of documentation:
https://kafka.apache.org/documentation/#remote_jmx