### PR TITLE
added support on jmx attributes of type java.util.Date

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -38,13 +38,13 @@ class JmxScraper {
 
     public static interface MBeanReceiver {
         void recordBean(
-                String domain,
-                LinkedHashMap<String, String> beanProperties,
-                LinkedList<String> attrKeys,
-                String attrName,
-                String attrType,
-                String attrDescription,
-                Object value);
+            String domain,
+            LinkedHashMap<String, String> beanProperties,
+            LinkedList<String> attrKeys,
+            String attrName,
+            String attrType,
+            String attrDescription,
+            Object value);
     }
 
     private final MBeanReceiver receiver;
@@ -69,30 +69,30 @@ class JmxScraper {
     }
 
     /**
-     * Get a list of mbeans on host_port and scrape their values.
-     *
-     * Values are passed to the receiver in a single thread.
-     */
+      * Get a list of mbeans on host_port and scrape their values.
+      *
+      * Values are passed to the receiver in a single thread.
+      */
     public void doScrape() throws Exception {
         MBeanServerConnection beanConn;
         JMXConnector jmxc = null;
         if (jmxUrl.isEmpty()) {
-            beanConn = ManagementFactory.getPlatformMBeanServer();
+          beanConn = ManagementFactory.getPlatformMBeanServer();
         } else {
-            Map<String, Object> environment = new HashMap<String, Object>();
-            if (username != null && username.length() != 0 && password != null && password.length() != 0) {
-                String[] credent = new String[] {username, password};
-                environment.put(javax.management.remote.JMXConnector.CREDENTIALS, credent);
-            }
-            if (ssl) {
-                environment.put(Context.SECURITY_PROTOCOL, "ssl");
-                SslRMIClientSocketFactory clientSocketFactory = new SslRMIClientSocketFactory();
-                environment.put(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE, clientSocketFactory);
-                environment.put("com.sun.jndi.rmi.factory.socket", clientSocketFactory);
-            }
+          Map<String, Object> environment = new HashMap<String, Object>();
+          if (username != null && username.length() != 0 && password != null && password.length() != 0) {
+            String[] credent = new String[] {username, password};
+            environment.put(javax.management.remote.JMXConnector.CREDENTIALS, credent);
+          }
+          if (ssl) {
+              environment.put(Context.SECURITY_PROTOCOL, "ssl");
+              SslRMIClientSocketFactory clientSocketFactory = new SslRMIClientSocketFactory();
+              environment.put(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE, clientSocketFactory);
+              environment.put("com.sun.jndi.rmi.factory.socket", clientSocketFactory);
+          }
 
-            jmxc = JMXConnectorFactory.connect(new JMXServiceURL(jmxUrl), environment);
-            beanConn = jmxc.getMBeanServerConnection();
+          jmxc = JMXConnectorFactory.connect(new JMXServiceURL(jmxUrl), environment);
+          beanConn = jmxc.getMBeanServerConnection();
         }
         try {
             // Query MBean names, see #89 for reasons queryMBeans() is used instead of queryNames()
@@ -118,22 +118,22 @@ class JmxScraper {
                 logger.fine("TIME: " + (System.nanoTime() - start) + " ns for " + objectName.toString());
             }
         } finally {
-            if (jmxc != null) {
-                jmxc.close();
-            }
+          if (jmxc != null) {
+            jmxc.close();
+          }
         }
     }
 
     private void scrapeBean(MBeanServerConnection beanConn, ObjectName mbeanName) {
         MBeanInfo info;
         try {
-            info = beanConn.getMBeanInfo(mbeanName);
+          info = beanConn.getMBeanInfo(mbeanName);
         } catch (IOException e) {
-            logScrape(mbeanName.toString(), "getMBeanInfo Fail: " + e);
-            return;
+          logScrape(mbeanName.toString(), "getMBeanInfo Fail: " + e);
+          return;
         } catch (JMException e) {
-            logScrape(mbeanName.toString(), "getMBeanInfo Fail: " + e);
-            return;
+          logScrape(mbeanName.toString(), "getMBeanInfo Fail: " + e);
+          return;
         }
         MBeanAttributeInfo[] attrInfos = info.getAttributes();
 
@@ -250,7 +250,7 @@ class JmxScraper {
                             // Nested tabulardata will repeat the 'key' label, so
                             // append a suffix to distinguish each.
                             while (l2s.containsKey(idx)) {
-                                idx = idx + "_";
+                              idx = idx + "_";
                             }
                             l2s.put(idx, obj.toString());
                         }
@@ -265,13 +265,13 @@ class JmxScraper {
                             name = attrName;
                         }
                         processBeanValue(
-                                domain,
-                                l2s,
-                                attrNames,
-                                name,
-                                typ,
-                                type.getDescription(),
-                                composite.get(valueIdx));
+                            domain,
+                            l2s,
+                            attrNames,
+                            name,
+                            typ,
+                            type.getDescription(),
+                            composite.get(valueIdx));
                     }
                 } else {
                     logScrape(domain, "not a correct tabulardata format");
@@ -299,18 +299,18 @@ class JmxScraper {
 
     private static class StdoutWriter implements MBeanReceiver {
         public void recordBean(
-                String domain,
-                LinkedHashMap<String, String> beanProperties,
-                LinkedList<String> attrKeys,
-                String attrName,
-                String attrType,
-                String attrDescription,
-                Object value) {
+            String domain,
+            LinkedHashMap<String, String> beanProperties,
+            LinkedList<String> attrKeys,
+            String attrName,
+            String attrType,
+            String attrDescription,
+            Object value) {
             System.out.println(domain +
-                    beanProperties +
-                    attrKeys +
-                    attrName +
-                    ": " + value);
+                               beanProperties +
+                               attrKeys +
+                               attrName +
+                               ": " + value);
         }
     }
 
@@ -318,20 +318,20 @@ class JmxScraper {
      * Convenience function to run standalone.
      */
     public static void main(String[] args) throws Exception {
-        List<ObjectName> objectNames = new LinkedList<ObjectName>();
-        objectNames.add(null);
-        if (args.length >= 3){
+      List<ObjectName> objectNames = new LinkedList<ObjectName>();
+      objectNames.add(null);
+      if (args.length >= 3){
             new JmxScraper(args[0], args[1], args[2], false, objectNames, new LinkedList<ObjectName>(),
                     new StdoutWriter(), new JmxMBeanPropertyCache()).doScrape();
         }
-        else if (args.length > 0){
-            new JmxScraper(args[0], "", "", false, objectNames, new LinkedList<ObjectName>(),
-                    new StdoutWriter(), new JmxMBeanPropertyCache()).doScrape();
-        }
-        else {
-            new JmxScraper("", "", "", false, objectNames, new LinkedList<ObjectName>(),
-                    new StdoutWriter(), new JmxMBeanPropertyCache()).doScrape();
-        }
+      else if (args.length > 0){
+          new JmxScraper(args[0], "", "", false, objectNames, new LinkedList<ObjectName>(),
+                  new StdoutWriter(), new JmxMBeanPropertyCache()).doScrape();
+      }
+      else {
+          new JmxScraper("", "", "", false, objectNames, new LinkedList<ObjectName>(),
+                  new StdoutWriter(), new JmxMBeanPropertyCache()).doScrape();
+      }
     }
 }
 

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -38,13 +38,13 @@ class JmxScraper {
 
     public static interface MBeanReceiver {
         void recordBean(
-            String domain,
-            LinkedHashMap<String, String> beanProperties,
-            LinkedList<String> attrKeys,
-            String attrName,
-            String attrType,
-            String attrDescription,
-            Object value);
+                String domain,
+                LinkedHashMap<String, String> beanProperties,
+                LinkedList<String> attrKeys,
+                String attrName,
+                String attrType,
+                String attrDescription,
+                Object value);
     }
 
     private final MBeanReceiver receiver;
@@ -69,30 +69,30 @@ class JmxScraper {
     }
 
     /**
-      * Get a list of mbeans on host_port and scrape their values.
-      *
-      * Values are passed to the receiver in a single thread.
-      */
+     * Get a list of mbeans on host_port and scrape their values.
+     *
+     * Values are passed to the receiver in a single thread.
+     */
     public void doScrape() throws Exception {
         MBeanServerConnection beanConn;
         JMXConnector jmxc = null;
         if (jmxUrl.isEmpty()) {
-          beanConn = ManagementFactory.getPlatformMBeanServer();
+            beanConn = ManagementFactory.getPlatformMBeanServer();
         } else {
-          Map<String, Object> environment = new HashMap<String, Object>();
-          if (username != null && username.length() != 0 && password != null && password.length() != 0) {
-            String[] credent = new String[] {username, password};
-            environment.put(javax.management.remote.JMXConnector.CREDENTIALS, credent);
-          }
-          if (ssl) {
-              environment.put(Context.SECURITY_PROTOCOL, "ssl");
-              SslRMIClientSocketFactory clientSocketFactory = new SslRMIClientSocketFactory();
-              environment.put(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE, clientSocketFactory);
-              environment.put("com.sun.jndi.rmi.factory.socket", clientSocketFactory);
-          }
+            Map<String, Object> environment = new HashMap<String, Object>();
+            if (username != null && username.length() != 0 && password != null && password.length() != 0) {
+                String[] credent = new String[] {username, password};
+                environment.put(javax.management.remote.JMXConnector.CREDENTIALS, credent);
+            }
+            if (ssl) {
+                environment.put(Context.SECURITY_PROTOCOL, "ssl");
+                SslRMIClientSocketFactory clientSocketFactory = new SslRMIClientSocketFactory();
+                environment.put(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE, clientSocketFactory);
+                environment.put("com.sun.jndi.rmi.factory.socket", clientSocketFactory);
+            }
 
-          jmxc = JMXConnectorFactory.connect(new JMXServiceURL(jmxUrl), environment);
-          beanConn = jmxc.getMBeanServerConnection();
+            jmxc = JMXConnectorFactory.connect(new JMXServiceURL(jmxUrl), environment);
+            beanConn = jmxc.getMBeanServerConnection();
         }
         try {
             // Query MBean names, see #89 for reasons queryMBeans() is used instead of queryNames()
@@ -118,22 +118,22 @@ class JmxScraper {
                 logger.fine("TIME: " + (System.nanoTime() - start) + " ns for " + objectName.toString());
             }
         } finally {
-          if (jmxc != null) {
-            jmxc.close();
-          }
+            if (jmxc != null) {
+                jmxc.close();
+            }
         }
     }
 
     private void scrapeBean(MBeanServerConnection beanConn, ObjectName mbeanName) {
         MBeanInfo info;
         try {
-          info = beanConn.getMBeanInfo(mbeanName);
+            info = beanConn.getMBeanInfo(mbeanName);
         } catch (IOException e) {
-          logScrape(mbeanName.toString(), "getMBeanInfo Fail: " + e);
-          return;
+            logScrape(mbeanName.toString(), "getMBeanInfo Fail: " + e);
+            return;
         } catch (JMException e) {
-          logScrape(mbeanName.toString(), "getMBeanInfo Fail: " + e);
-          return;
+            logScrape(mbeanName.toString(), "getMBeanInfo Fail: " + e);
+            return;
         }
         MBeanAttributeInfo[] attrInfos = info.getAttributes();
 
@@ -191,10 +191,9 @@ class JmxScraper {
         if (value == null) {
             logScrape(domain + beanProperties + attrName, "null");
         } else if (value instanceof Number || value instanceof String || value instanceof Boolean || value instanceof java.util.Date) {
-            //output Date as Long (the number of seconds since January 1, 1970, 00:00:00 GMT)
             if(value instanceof java.util.Date){
-                attrType = "java.lang.Long";
-                value = ((java.util.Date)value).getTime() / 1000;
+                attrType = "java.lang.Double";
+                value = (double) ((java.util.Date) value).getTime() / 1000;
             }
             logScrape(domain + beanProperties + attrName, value.toString());
             this.receiver.recordBean(
@@ -251,7 +250,7 @@ class JmxScraper {
                             // Nested tabulardata will repeat the 'key' label, so
                             // append a suffix to distinguish each.
                             while (l2s.containsKey(idx)) {
-                              idx = idx + "_";
+                                idx = idx + "_";
                             }
                             l2s.put(idx, obj.toString());
                         }
@@ -266,13 +265,13 @@ class JmxScraper {
                             name = attrName;
                         }
                         processBeanValue(
-                            domain,
-                            l2s,
-                            attrNames,
-                            name,
-                            typ,
-                            type.getDescription(),
-                            composite.get(valueIdx));
+                                domain,
+                                l2s,
+                                attrNames,
+                                name,
+                                typ,
+                                type.getDescription(),
+                                composite.get(valueIdx));
                     }
                 } else {
                     logScrape(domain, "not a correct tabulardata format");
@@ -300,18 +299,18 @@ class JmxScraper {
 
     private static class StdoutWriter implements MBeanReceiver {
         public void recordBean(
-            String domain,
-            LinkedHashMap<String, String> beanProperties,
-            LinkedList<String> attrKeys,
-            String attrName,
-            String attrType,
-            String attrDescription,
-            Object value) {
+                String domain,
+                LinkedHashMap<String, String> beanProperties,
+                LinkedList<String> attrKeys,
+                String attrName,
+                String attrType,
+                String attrDescription,
+                Object value) {
             System.out.println(domain +
-                               beanProperties +
-                               attrKeys +
-                               attrName +
-                               ": " + value);
+                    beanProperties +
+                    attrKeys +
+                    attrName +
+                    ": " + value);
         }
     }
 
@@ -319,20 +318,20 @@ class JmxScraper {
      * Convenience function to run standalone.
      */
     public static void main(String[] args) throws Exception {
-      List<ObjectName> objectNames = new LinkedList<ObjectName>();
-      objectNames.add(null);
-      if (args.length >= 3){
+        List<ObjectName> objectNames = new LinkedList<ObjectName>();
+        objectNames.add(null);
+        if (args.length >= 3){
             new JmxScraper(args[0], args[1], args[2], false, objectNames, new LinkedList<ObjectName>(),
                     new StdoutWriter(), new JmxMBeanPropertyCache()).doScrape();
         }
-      else if (args.length > 0){
-          new JmxScraper(args[0], "", "", false, objectNames, new LinkedList<ObjectName>(),
-                  new StdoutWriter(), new JmxMBeanPropertyCache()).doScrape();
-      }
-      else {
-          new JmxScraper("", "", "", false, objectNames, new LinkedList<ObjectName>(),
-                  new StdoutWriter(), new JmxMBeanPropertyCache()).doScrape();
-      }
+        else if (args.length > 0){
+            new JmxScraper(args[0], "", "", false, objectNames, new LinkedList<ObjectName>(),
+                    new StdoutWriter(), new JmxMBeanPropertyCache()).doScrape();
+        }
+        else {
+            new JmxScraper("", "", "", false, objectNames, new LinkedList<ObjectName>(),
+                    new StdoutWriter(), new JmxMBeanPropertyCache()).doScrape();
+        }
     }
 }
 

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -191,9 +191,9 @@ class JmxScraper {
         if (value == null) {
             logScrape(domain + beanProperties + attrName, "null");
         } else if (value instanceof Number || value instanceof String || value instanceof Boolean || value instanceof java.util.Date) {
-            if(value instanceof java.util.Date){
+            if (value instanceof java.util.Date) {
                 attrType = "java.lang.Double";
-                value = (double) ((java.util.Date) value).getTime() / 1000;
+                value = ((java.util.Date) value).getTime() / 1000.0;
             }
             logScrape(domain + beanProperties + attrName, value.toString());
             this.receiver.recordBean(

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -191,10 +191,10 @@ class JmxScraper {
         if (value == null) {
             logScrape(domain + beanProperties + attrName, "null");
         } else if (value instanceof Number || value instanceof String || value instanceof Boolean || value instanceof java.util.Date) {
-            //output Date as Long (the number of milliseconds since January 1, 1970, 00:00:00 GMT)
-            if( value instanceof java.util.Date){
+            //output Date as Long (the number of seconds since January 1, 1970, 00:00:00 GMT)
+            if(value instanceof java.util.Date){
                 attrType = "java.lang.Long";
-                value = ((java.util.Date)value).getTime();
+                value = ((java.util.Date)value).getTime() / 1000;
             }
             logScrape(domain + beanProperties + attrName, value.toString());
             this.receiver.recordBean(

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -190,7 +190,12 @@ class JmxScraper {
             Object value) {
         if (value == null) {
             logScrape(domain + beanProperties + attrName, "null");
-        } else if (value instanceof Number || value instanceof String || value instanceof Boolean) {
+        } else if (value instanceof Number || value instanceof String || value instanceof Boolean || value instanceof java.util.Date) {
+            //output Date as Long (the number of milliseconds since January 1, 1970, 00:00:00 GMT)
+            if( value instanceof java.util.Date){
+                attrType = "java.lang.Long";
+                value = ((java.util.Date)value).getTime();
+            }
             logScrape(domain + beanProperties + attrName, value.toString());
             this.receiver.recordBean(
                     domain,
@@ -259,7 +264,7 @@ class JmxScraper {
                             // Skip appending 'value' to the name
                             attrNames = attrKeys;
                             name = attrName;
-                        } 
+                        }
                         processBeanValue(
                             domain,
                             l2s,
@@ -303,7 +308,7 @@ class JmxScraper {
             String attrDescription,
             Object value) {
             System.out.println(domain +
-                               beanProperties + 
+                               beanProperties +
                                attrKeys +
                                attrName +
                                ": " + value);

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -263,7 +263,7 @@ class JmxScraper {
                             // Skip appending 'value' to the name
                             attrNames = attrKeys;
                             name = attrName;
-                        }
+                        } 
                         processBeanValue(
                             domain,
                             l2s,
@@ -307,7 +307,7 @@ class JmxScraper {
             String attrDescription,
             Object value) {
             System.out.println(domain +
-                               beanProperties +
+                               beanProperties + 
                                attrKeys +
                                attrName +
                                ": " + value);

--- a/collector/src/test/java/io/prometheus/jmx/CamelMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/CamelMBean.java
@@ -2,12 +2,10 @@ package io.prometheus.jmx;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
-import java.util.Calendar;
 import java.util.Date;
-import java.util.Random;
 
 public interface CamelMBean {
-    long EXPECTED_DATE_IN_SECONDS = 1573285945L;
+    long EXPECTED_DATE_IN_MILLISECONDS = 1573285945111L;
     Date getLastExchangeFailureTimestamp();
 }
 
@@ -22,7 +20,6 @@ class Camel implements CamelMBean{
 
     @Override
     public Date getLastExchangeFailureTimestamp() {
-        int theMillisecondAtTheMoment = Calendar.getInstance().get(Calendar.MILLISECOND);
-        return new Date(EXPECTED_DATE_IN_SECONDS * 1000 + theMillisecondAtTheMoment);
+        return new Date(EXPECTED_DATE_IN_MILLISECONDS);
     }
 }

--- a/collector/src/test/java/io/prometheus/jmx/CamelMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/CamelMBean.java
@@ -5,21 +5,22 @@ import javax.management.ObjectName;
 import java.util.Date;
 
 public interface CamelMBean {
-    long EXPECTED_DATE_IN_MILLISECONDS = 1573285945111L;
-    Date getLastExchangeFailureTimestamp();
+  long EXPECTED_DATE_IN_MILLISECONDS = 1573285945111L;
+
+  Date getLastExchangeFailureTimestamp();
 }
 
-class Camel implements CamelMBean{
-    public static void registerBean(MBeanServer mbs)
-            throws javax.management.JMException {
-        ObjectName mbeanName = new ObjectName(
-                "org.apache.camel:context=my-camel-context,type=routes,name=\"my-route-name\"");
-        Camel mbean = new Camel();
-        mbs.registerMBean(mbean, mbeanName);
-    }
+class Camel implements CamelMBean {
+  public static void registerBean(MBeanServer mbs)
+          throws javax.management.JMException {
+    ObjectName mbeanName = new ObjectName(
+            "org.apache.camel:context=my-camel-context,type=routes,name=\"my-route-name\"");
+    Camel mbean = new Camel();
+    mbs.registerMBean(mbean, mbeanName);
+  }
 
-    @Override
-    public Date getLastExchangeFailureTimestamp() {
-        return new Date(EXPECTED_DATE_IN_MILLISECONDS);
-    }
+  @Override
+  public Date getLastExchangeFailureTimestamp() {
+    return new Date(EXPECTED_DATE_IN_MILLISECONDS);
+  }
 }

--- a/collector/src/test/java/io/prometheus/jmx/CamelMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/CamelMBean.java
@@ -1,0 +1,23 @@
+package io.prometheus.jmx;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+public interface CamelMBean {
+    long getLastExchangeFailureTimestamp();
+}
+
+class Camel implements CamelMBean{
+    public static void registerBean(MBeanServer mbs)
+            throws javax.management.JMException {
+        ObjectName mbeanName = new ObjectName(
+                "org.apache.camel:context=my-camel-context,type=routes,name=\"my-route-name\"");
+        Camel mbean = new Camel();
+        mbs.registerMBean(mbean, mbeanName);
+    }
+
+    @Override
+    public long getLastExchangeFailureTimestamp() {
+        return 1573285945806L;
+    }
+}

--- a/collector/src/test/java/io/prometheus/jmx/CamelMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/CamelMBean.java
@@ -2,9 +2,13 @@ package io.prometheus.jmx;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Random;
 
 public interface CamelMBean {
-    long getLastExchangeFailureTimestamp();
+    long EXPECTED_DATE_IN_SECONDS = 1573285945L;
+    Date getLastExchangeFailureTimestamp();
 }
 
 class Camel implements CamelMBean{
@@ -17,7 +21,8 @@ class Camel implements CamelMBean{
     }
 
     @Override
-    public long getLastExchangeFailureTimestamp() {
-        return 1573285945806L;
+    public Date getLastExchangeFailureTimestamp() {
+        int theMillisecondAtTheMoment = Calendar.getInstance().get(Calendar.MILLISECOND);
+        return new Date(EXPECTED_DATE_IN_SECONDS * 1000 + theMillisecondAtTheMoment);
     }
 }

--- a/collector/src/test/java/io/prometheus/jmx/CamelMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/CamelMBean.java
@@ -5,7 +5,7 @@ import javax.management.ObjectName;
 import java.util.Date;
 
 public interface CamelMBean {
-  long EXPECTED_DATE_IN_MILLISECONDS = 1573285945111L;
+  double EXPECTED_SECONDS = 1.573285945111E9;
 
   Date getLastExchangeFailureTimestamp();
 }
@@ -21,6 +21,6 @@ class Camel implements CamelMBean {
 
   @Override
   public Date getLastExchangeFailureTimestamp() {
-    return new Date(EXPECTED_DATE_IN_MILLISECONDS);
+    return new Date((long)(EXPECTED_SECONDS * 1000));
   }
 }

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -266,6 +266,6 @@ public class JmxCollectorTest {
                         "    route: \"$2\"\n" +
                         "    type: routes";
         JmxCollector jc = new JmxCollector(rulePattern).register(registry);
-        assertEquals(Double.valueOf(Camel.EXPECTED_DATE_IN_SECONDS), registry.getSampleValue("org_apache_camel_LastExchangeFailureTimestamp", new String[]{"context", "route", "type"}, new String[]{"my-camel-context", "my-route-name", "routes"}));
+        assertEquals(Double.valueOf((double)Camel.EXPECTED_DATE_IN_MILLISECONDS / 1000), registry.getSampleValue("org_apache_camel_LastExchangeFailureTimestamp", new String[]{"context", "route", "type"}, new String[]{"my-camel-context", "my-route-name", "routes"}));
     }
 }

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -31,6 +31,7 @@ public class JmxCollectorTest {
 
         TomcatServlet.registerBean(mbs);
         Bool.registerBean(mbs);
+        Camel.registerBean(mbs);
     }
 
     @Before
@@ -251,5 +252,20 @@ public class JmxCollectorTest {
       JmxCollector jc = new JmxCollector("---\nstartDelaySeconds: 1").register(registry);
       Thread.sleep(2000);
       assertEquals(1.0, registry.getSampleValue("boolean_Test_True", new String[]{}, new String[]{}), .001);
+    }
+
+    @Test
+    public void testCamelLastExchangFailureTimestamp() throws Exception{
+        String rulePattern =
+                "\n---\nrules:\n- pattern: 'org.apache.camel<context=([^,]+), type=routes, name=\"([^\"]+)\"><>LastExchangeFailureTimestamp'\n" +
+                        "  name: org.apache.camel.LastExchangeFailureTimestamp\n" +
+                        "  help: Exchanges Last Failure Timestamps\n" +
+                        "  type: UNTYPED\n" +
+                        "  labels:\n" +
+                        "    context: \"$1\"\n" +
+                        "    route: \"$2\"\n" +
+                        "    type: routes";
+        JmxCollector jc = new JmxCollector(rulePattern).register(registry);
+        assertEquals(Double.valueOf(1573285945806L), registry.getSampleValue("org_apache_camel_LastExchangeFailureTimestamp", new String[]{"context", "route", "type"}, new String[]{"my-camel-context", "my-route-name", "routes"}));
     }
 }

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -266,6 +266,6 @@ public class JmxCollectorTest {
                         "    route: \"$2\"\n" +
                         "    type: routes";
         JmxCollector jc = new JmxCollector(rulePattern).register(registry);
-        assertEquals(Double.valueOf(1573285945806L), registry.getSampleValue("org_apache_camel_LastExchangeFailureTimestamp", new String[]{"context", "route", "type"}, new String[]{"my-camel-context", "my-route-name", "routes"}));
+        assertEquals(Double.valueOf(Camel.EXPECTED_DATE_IN_SECONDS), registry.getSampleValue("org_apache_camel_LastExchangeFailureTimestamp", new String[]{"context", "route", "type"}, new String[]{"my-camel-context", "my-route-name", "routes"}));
     }
 }

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -266,6 +266,7 @@ public class JmxCollectorTest {
                       "    route: \"$2\"\n" +
                       "    type: routes";
       JmxCollector jc = new JmxCollector(rulePattern).register(registry);
-      assertEquals(Double.valueOf((double)Camel.EXPECTED_DATE_IN_MILLISECONDS / 1000), registry.getSampleValue("org_apache_camel_LastExchangeFailureTimestamp", new String[]{"context", "route", "type"}, new String[]{"my-camel-context", "my-route-name", "routes"}));
+      Double actual = registry.getSampleValue("org_apache_camel_LastExchangeFailureTimestamp", new String[]{"context", "route", "type"}, new String[]{"my-camel-context", "my-route-name", "routes"});
+      assertEquals(Camel.EXPECTED_SECONDS, actual, 0);
     }
 }

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -256,16 +256,16 @@ public class JmxCollectorTest {
 
     @Test
     public void testCamelLastExchangFailureTimestamp() throws Exception{
-        String rulePattern =
-                "\n---\nrules:\n- pattern: 'org.apache.camel<context=([^,]+), type=routes, name=\"([^\"]+)\"><>LastExchangeFailureTimestamp'\n" +
-                        "  name: org.apache.camel.LastExchangeFailureTimestamp\n" +
-                        "  help: Exchanges Last Failure Timestamps\n" +
-                        "  type: UNTYPED\n" +
-                        "  labels:\n" +
-                        "    context: \"$1\"\n" +
-                        "    route: \"$2\"\n" +
-                        "    type: routes";
-        JmxCollector jc = new JmxCollector(rulePattern).register(registry);
-        assertEquals(Double.valueOf((double)Camel.EXPECTED_DATE_IN_MILLISECONDS / 1000), registry.getSampleValue("org_apache_camel_LastExchangeFailureTimestamp", new String[]{"context", "route", "type"}, new String[]{"my-camel-context", "my-route-name", "routes"}));
+      String rulePattern =
+              "\n---\nrules:\n- pattern: 'org.apache.camel<context=([^,]+), type=routes, name=\"([^\"]+)\"><>LastExchangeFailureTimestamp'\n" +
+                      "  name: org.apache.camel.LastExchangeFailureTimestamp\n" +
+                      "  help: Exchanges Last Failure Timestamps\n" +
+                      "  type: UNTYPED\n" +
+                      "  labels:\n" +
+                      "    context: \"$1\"\n" +
+                      "    route: \"$2\"\n" +
+                      "    type: routes";
+      JmxCollector jc = new JmxCollector(rulePattern).register(registry);
+      assertEquals(Double.valueOf((double)Camel.EXPECTED_DATE_IN_MILLISECONDS / 1000), registry.getSampleValue("org_apache_camel_LastExchangeFailureTimestamp", new String[]{"context", "route", "type"}, new String[]{"my-camel-context", "my-route-name", "routes"}));
     }
 }


### PR DESCRIPTION
Dear maintainers,

We recently had an requirement to expose certain JMX attributes of java Date type to prometheus, specifically, a number of timestamps in the built-in JMX of Apache Camel library.

We thought that it might be useful for other users of the exporter, would you review our changes and let us know any feedbacks and critics please?

Thank you
Jacky