### PR TITLE
Fix config for zookeeper standalone

### DIFF
--- a/example_configs/zookeeper.yaml
+++ b/example_configs/zookeeper.yaml
@@ -17,7 +17,7 @@ rules:
       replicaId: "$2"
       memberType: "$3"
   # standalone Zookeeper
-  - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+)><>(\\w+)"
+  - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port-(\\d+)><>(\\w+)"
     name: "zookeeper_$2"
-  - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+), name1=InMemoryDataTree><>(\\w+)"
+  - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port-(\\d+), name1=InMemoryDataTree><>(\\w+)"
     name: "zookeeper_$2"


### PR DESCRIPTION
The metrics from the JMX exporter have this format: 
```
org.apache.ZooKeeperService<name0=StandaloneServer_port-1><>MinRequestLatency)
```
So the regexp needs a `-` after `port`.