### PR TITLE
Add all avg metrics of kafka broker

### DIFF
--- a/example_configs/kafka-2_0_0.yml
+++ b/example_configs/kafka-2_0_0.yml
@@ -87,6 +87,12 @@ rules:
   type: COUNTER
   labels:
     "$4": "$5"
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Mean
+  name: kafka_$1_$2_$3
+  type: GAUGE
+  labels:
+    "$4": "$5"
+    quantile: "avg"
 - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*)><>(\d+)thPercentile
   name: kafka_$1_$2_$3
   type: GAUGE


### PR DESCRIPTION
Hi @brian-brazil. In this PR I added a regex for to get the avg type metrics (Mean).

The regexp bellow get only metrics of the type thPercentile.
```
- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*)><>(\d+)thPercentile
  name: kafka_$1_$2_$3
  type: GAUGE
  labels:
    "$4": "$5"
    quantile: "0.$6"
```

But for the Apache Kafka is very import know the metrics of the type avg as well. 

Now with the metrics of this PR it is possible filter the quantile with 0.50, 0.75, 0.99, 0.999 or avg.