### PR TITLE
Added support for custom JMX connector properties (#469)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ username:
 password: 
 jmxUrl: service:jmx:rmi:///jndi/rmi://127.0.0.1:1234/jmxrmi
 ssl: false
+jmxEnvironment:
+  "some.useful.property": "any string value"
+  "another.jmx.connector.property": "customValue"
 lowercaseOutputName: false
 lowercaseOutputLabelNames: false
 whitelistObjectNames: ["org.apache.cassandra.metrics:*"]
@@ -58,10 +61,11 @@ Name     | Description
 ---------|------------
 startDelaySeconds | start delay before serving requests. Any requests within the delay period will result in an empty metrics set.
 hostPort | The host and port to connect to via remote JMX. If neither this nor jmxUrl is specified, will talk to the local JVM.
-username | The username to be used in remote JMX password authentication.
-password | The password to be used in remote JMX password authentication.
+username | The username to be used in remote JMX password authentication (used for `jmx.remote.credentials` JMX-connector property).
+password | The password to be used in remote JMX password authentication (used for `jmx.remote.credentials` JMX-connector property).
 jmxUrl   | A full JMX URL to connect to. Should not be specified if hostPort is.
-ssl      | Whether JMX connection should be done over SSL. To configure certificates you have to set following system properties:<br/>`-Djavax.net.ssl.keyStore=/home/user/.keystore`<br/>`-Djavax.net.ssl.keyStorePassword=changeit`<br/>`-Djavax.net.ssl.trustStore=/home/user/.truststore`<br/>`-Djavax.net.ssl.trustStorePassword=changeit`
+ssl      | Whether JMX connection should be done over SSL. Note this only sets RMI/JRMP standard properties, other RMI implementations (e.g. WebLogic, JBoss, IIOP) may not be affected! To configure certificates you have to set following system properties:<br/>`-Djavax.net.ssl.keyStore=/home/user/.keystore`<br/>`-Djavax.net.ssl.keyStorePassword=changeit`<br/>`-Djavax.net.ssl.trustStore=/home/user/.truststore`<br/>`-Djavax.net.ssl.trustStorePassword=changeit`
+jmxEnvironment | Properties passed directly to JMX-connector. Can be used to configure proprietary RMI protocol implementations and more nuanced properties. Typically not needed for "standard" use cases. 
 lowercaseOutputName | Lowercase the output metric name. Applies to default format and `name`. Defaults to false.
 lowercaseOutputLabelNames | Lowercase the output metric label names. Applies to default format and `labels`. Defaults to false.
 whitelistObjectNames | A list of [ObjectNames](http://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html) to query. Defaults to all mBeans.

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -52,10 +53,11 @@ class JmxScraper {
     private final String username;
     private final String password;
     private final boolean ssl;
+    private final Map<String, String> jmxEnv;
     private final List<ObjectName> whitelistObjectNames, blacklistObjectNames;
     private final JmxMBeanPropertyCache jmxMBeanPropertyCache;
 
-    public JmxScraper(String jmxUrl, String username, String password, boolean ssl,
+    public JmxScraper(String jmxUrl, String username, String password, boolean ssl, Map<String, String> jmxEnv,
                       List<ObjectName> whitelistObjectNames, List<ObjectName> blacklistObjectNames,
                       MBeanReceiver receiver, JmxMBeanPropertyCache jmxMBeanPropertyCache) {
         this.jmxUrl = jmxUrl;
@@ -63,6 +65,7 @@ class JmxScraper {
         this.username = username;
         this.password = password;
         this.ssl = ssl;
+        this.jmxEnv = jmxEnv;
         this.whitelistObjectNames = whitelistObjectNames;
         this.blacklistObjectNames = blacklistObjectNames;
         this.jmxMBeanPropertyCache = jmxMBeanPropertyCache;
@@ -89,6 +92,9 @@ class JmxScraper {
               SslRMIClientSocketFactory clientSocketFactory = new SslRMIClientSocketFactory();
               environment.put(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE, clientSocketFactory);
               environment.put("com.sun.jndi.rmi.factory.socket", clientSocketFactory);
+          }
+          if(!jmxEnv.isEmpty()) {
+              environment.putAll(jmxEnv);
           }
 
           jmxc = JMXConnectorFactory.connect(new JMXServiceURL(jmxUrl), environment);
@@ -319,17 +325,18 @@ class JmxScraper {
      */
     public static void main(String[] args) throws Exception {
       List<ObjectName> objectNames = new LinkedList<ObjectName>();
+      Map<String, String> jmxEnv=Collections.emptyMap();
       objectNames.add(null);
       if (args.length >= 3){
-            new JmxScraper(args[0], args[1], args[2], false, objectNames, new LinkedList<ObjectName>(),
+            new JmxScraper(args[0], args[1], args[2], false, jmxEnv, objectNames, new LinkedList<ObjectName>(),
                     new StdoutWriter(), new JmxMBeanPropertyCache()).doScrape();
         }
       else if (args.length > 0){
-          new JmxScraper(args[0], "", "", false, objectNames, new LinkedList<ObjectName>(),
+          new JmxScraper(args[0], "", "", false, jmxEnv, objectNames, new LinkedList<ObjectName>(),
                   new StdoutWriter(), new JmxMBeanPropertyCache()).doScrape();
       }
       else {
-          new JmxScraper("", "", "", false, objectNames, new LinkedList<ObjectName>(),
+          new JmxScraper("", "", "", false, jmxEnv, objectNames, new LinkedList<ObjectName>(),
                   new StdoutWriter(), new JmxMBeanPropertyCache()).doScrape();
       }
     }

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -269,4 +269,33 @@ public class JmxCollectorTest {
       Double actual = registry.getSampleValue("org_apache_camel_LastExchangeFailureTimestamp", new String[]{"context", "route", "type"}, new String[]{"my-camel-context", "my-route-name", "routes"});
       assertEquals(Camel.EXPECTED_SECONDS, actual, 0);
     }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testJmxEnvMustNotContainObject() throws Exception {
+        new JmxCollector("---\njmxEnvironment:\n  some.custom.object:\n    subObject:\n      key: value\n");
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testJmxEnvMustNotContainList() throws Exception {
+        new JmxCollector("---\njmxEnvironment:\n  - key.one: value1\n  - key2: value2\n");
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testJmxEnvMustNotContainSubList() throws Exception {
+        new JmxCollector(
+            "---\n" +
+            "jmxEnvironment:\n" +
+            "  some.custom.object:\n" +
+            "    - key1: value1\n" +
+            "    - key2: value2\n");
+    }
+
+    @Test
+    public void testJmxEnvironmentLoading() throws Exception {
+        new JmxCollector((
+                "---\n" +
+                "jmxEnvironment:\n" +
+                "  some.custom.property: some.value\n" +
+                "  `quoted.property`: `quoted.value`\n").replace('`','"'));
+    }
 }

--- a/example_configs/weblogic-t3s.yml
+++ b/example_configs/weblogic-t3s.yml
@@ -1,0 +1,12 @@
+---
+# A minimal example for connecting remotely to WebLogic via t3(s).
+# Important: `wlthint3client.jar` must be in the classpath, so do NOT start the JVM with `-jar` as it ignores `-cp`!
+jmxUrl: service:jmx:t3s://weblogic.host:wlPort/jndi/weblogic.management.mbeanservers.domainruntime
+jmxEnvironment:
+  "jmx.remote.protocol.provider.pkgs": "weblogic.management.remote"
+  "java.naming.security.principal": "wluser"
+  "java.naming.security.credentials": "wlpass"
+
+# For other properties s, including weblogic specific `weblogic.yml` (don't scrape *all* of weblogic :-) )
+rules:
+  - pattern: ".*"


### PR DESCRIPTION
Adds ability to configure custom JMX connector properties in YAML config (e.g. for more involved remote connections), fixes issue #469 (full disclosure: created by me).

@brian-brazil 
@VladimirYushkevich 