### PR TITLE
Fix incorrect 'java' path when JAVA_HOME isn't empty

### DIFF
--- a/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/JavaAgentIT.java
+++ b/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/JavaAgentIT.java
@@ -17,6 +17,10 @@ import java.util.List;
 import org.junit.Test;
 
 public class JavaAgentIT {
+
+    private static final String DEFAULT_JAVA_HOME_PATH = "/bin/java";
+    private static final String DEFAULT_JAVA_PATH = "java";
+
     private List<URL> getClassloaderUrls() {
         return getClassloaderUrls(getClass().getClassLoader());
     }
@@ -56,14 +60,7 @@ public class JavaAgentIT {
         final int port = Integer.parseInt((String) System.getProperties().get("it.port"));
         final String config = resolveRelativePathToResource("test.yml");
         final String javaagent = "-javaagent:" + buildDirectory + "/" + finalName + ".jar=" + port + ":" + config;
-
-        final String javaHome = System.getenv("JAVA_HOME");
-        final String java;
-        if (javaHome != null && javaHome.equals("")) {
-            java = javaHome + "/bin/java";
-        } else {
-            java = "java";
-        }
+        final String java = buildJavaPath(System.getenv("JAVA_HOME"));
 
         final Process app = new ProcessBuilder()
             .command(java, javaagent, "-cp", buildClasspath(), "io.prometheus.jmx.TestApplication")
@@ -104,6 +101,14 @@ public class JavaAgentIT {
 
             assertThat("Application did not exit cleanly", exitcode == 0);
         }
+    }
+
+    private String buildJavaPath(String javaHome) {
+        if (!(javaHome == null || javaHome.isEmpty())) {
+            return javaHome + DEFAULT_JAVA_HOME_PATH;
+        }
+
+        return DEFAULT_JAVA_PATH;
     }
 
     //trying to avoid the occurrence of any : in the windows path


### PR DESCRIPTION
Hi guys! 
You build the important staff, we are using your tool for our ActiveMq instance.

I made a little fix for this:
https://github.com/prometheus/jmx_exporter/issues/405