### PR TITLE
Allow caching regular expression matching in rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ value             | Value for the metric. Static values and capture groups from 
 valueFactor       | Optional number that `value` (or the scraped mBean value if `value` is not specified) is multiplied by, mainly used to convert mBean values from milliseconds to seconds.
 labels            | A map of label name to label value pairs. Capture groups from `pattern` can be used in each. `name` must be set to use this. Empty names and values are ignored. If not specified and the default format is not being used, no labels are set.
 help              | Help text for the metric. Capture groups from `pattern` can be used. `name` must be set to use this. Defaults to the mBean attribute description and the full name of the attribute.
-matchBeanValue    | Whether to append the bean value in the expression to match patterns against for this rule. (e.g: "beanName<beanType>: <beanValue>"). Defaults to `true`.
 cache             | Whether to cache bean name expressions to rule computation (match and mismatch). This can increase performance when collecting a lot of mbeans. Defaults to `false`.
 type              | The type of the metric, can be `GAUGE`, `COUNTER` or `UNTYPED`. `name` must be set to use this. Defaults to `UNTYPED`.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ value             | Value for the metric. Static values and capture groups from 
 valueFactor       | Optional number that `value` (or the scraped mBean value if `value` is not specified) is multiplied by, mainly used to convert mBean values from milliseconds to seconds.
 labels            | A map of label name to label value pairs. Capture groups from `pattern` can be used in each. `name` must be set to use this. Empty names and values are ignored. If not specified and the default format is not being used, no labels are set.
 help              | Help text for the metric. Capture groups from `pattern` can be used. `name` must be set to use this. Defaults to the mBean attribute description and the full name of the attribute.
-cache             | Whether to cache bean name expressions to rule computation (match and mismatch). This can increase performance when collecting a lot of mbeans. Defaults to `false`.
+cache             | Whether to cache bean name expressions to rule computation (match and mismatch). Not recommended for rules matching on bean value only the first value will be cached and re-used. This can increase performance when collecting a lot of mbeans. Defaults to `false`.
 type              | The type of the metric, can be `GAUGE`, `COUNTER` or `UNTYPED`. `name` must be set to use this. Defaults to `UNTYPED`.
 
 Metric names and label names are sanitized. All characters other than `[a-zA-Z0-9:_]` are replaced with underscores,

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ rules:
     valueFactor: 0.001
     labels: {}
     help: "Cassandra metric $1 $2"
-    matchBeanValue: true
     cache: false
     type: GAUGE
     attrNameSnakeCase: false

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ lowercaseOutputName: false
 lowercaseOutputLabelNames: false
 whitelistObjectNames: ["org.apache.cassandra.metrics:*"]
 blacklistObjectNames: ["org.apache.cassandra.metrics:type=ColumnFamily,*"]
+cacheRules: false
 rules:
   - pattern: 'org.apache.cassandra.metrics<type=(\w+), name=(\w+)><>Value: (\d+)'
     name: cassandra_$1_$2
@@ -57,16 +58,17 @@ rules:
 Name     | Description
 ---------|------------
 startDelaySeconds | start delay before serving requests. Any requests within the delay period will result in an empty metrics set.
-hostPort | The host and port to connect to via remote JMX. If neither this nor jmxUrl is specified, will talk to the local JVM.
-username | The username to be used in remote JMX password authentication.
-password | The password to be used in remote JMX password authentication.
-jmxUrl   | A full JMX URL to connect to. Should not be specified if hostPort is.
-ssl      | Whether JMX connection should be done over SSL. To configure certificates you have to set following system properties:<br/>`-Djavax.net.ssl.keyStore=/home/user/.keystore`<br/>`-Djavax.net.ssl.keyStorePassword=changeit`<br/>`-Djavax.net.ssl.trustStore=/home/user/.truststore`<br/>`-Djavax.net.ssl.trustStorePassword=changeit`
+hostPort   | The host and port to connect to via remote JMX. If neither this nor jmxUrl is specified, will talk to the local JVM.
+username   | The username to be used in remote JMX password authentication.
+password   | The password to be used in remote JMX password authentication.
+jmxUrl     | A full JMX URL to connect to. Should not be specified if hostPort is.
+ssl        | Whether JMX connection should be done over SSL. To configure certificates you have to set following system properties:<br/>`-Djavax.net.ssl.keyStore=/home/user/.keystore`<br/>`-Djavax.net.ssl.keyStorePassword=changeit`<br/>`-Djavax.net.ssl.trustStore=/home/user/.truststore`<br/>`-Djavax.net.ssl.trustStorePassword=changeit`
 lowercaseOutputName | Lowercase the output metric name. Applies to default format and `name`. Defaults to false.
 lowercaseOutputLabelNames | Lowercase the output metric label names. Applies to default format and `labels`. Defaults to false.
 whitelistObjectNames | A list of [ObjectNames](http://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html) to query. Defaults to all mBeans.
 blacklistObjectNames | A list of [ObjectNames](http://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html) to not query. Takes precedence over `whitelistObjectNames`. Defaults to none.
-rules    | A list of rules to apply in order, processing stops at the first matching rule. Attributes that aren't matched aren't collected. If not specified, defaults to collecting everything in the default format.
+cacheRules | Whether to cach bean to rule computation. If true, bean values are ommitted from patterns when matching.
+rules      | A list of rules to apply in order, processing stops at the first matching rule. Attributes that aren't matched aren't collected. If not specified, defaults to collecting everything in the default format.
 pattern  | Regex pattern to match against each bean attribute. The pattern is not anchored. Capture groups can be used in other options. Defaults to matching everything.
 attrNameSnakeCase | Converts the attribute name to snake case. This is seen in the names matched by the pattern and the default format. For example, anAttrName to an\_attr\_name. Defaults to false.
 name     | The metric name to set. Capture groups from the `pattern` can be used. If not specified, the default format will be used. If it evaluates to empty, processing of this attribute stops with no output.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ lowercaseOutputName: false
 lowercaseOutputLabelNames: false
 whitelistObjectNames: ["org.apache.cassandra.metrics:*"]
 blacklistObjectNames: ["org.apache.cassandra.metrics:type=ColumnFamily,*"]
-cacheRules: false
 rules:
   - pattern: 'org.apache.cassandra.metrics<type=(\w+), name=(\w+)><>Value: (\d+)'
     name: cassandra_$1_$2
@@ -52,6 +51,8 @@ rules:
     valueFactor: 0.001
     labels: {}
     help: "Cassandra metric $1 $2"
+    matchBeanValue: true
+    cache: false
     type: GAUGE
     attrNameSnakeCase: false
 ```
@@ -67,16 +68,17 @@ lowercaseOutputName | Lowercase the output metric name. Applies to default forma
 lowercaseOutputLabelNames | Lowercase the output metric label names. Applies to default format and `labels`. Defaults to false.
 whitelistObjectNames | A list of [ObjectNames](http://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html) to query. Defaults to all mBeans.
 blacklistObjectNames | A list of [ObjectNames](http://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html) to not query. Takes precedence over `whitelistObjectNames`. Defaults to none.
-cacheRules | Whether to cach bean to rule computation. If true, bean values are ommitted from patterns when matching.
 rules      | A list of rules to apply in order, processing stops at the first matching rule. Attributes that aren't matched aren't collected. If not specified, defaults to collecting everything in the default format.
-pattern  | Regex pattern to match against each bean attribute. The pattern is not anchored. Capture groups can be used in other options. Defaults to matching everything.
+pattern           | Regex pattern to match against each bean attribute. The pattern is not anchored. Capture groups can be used in other options. Defaults to matching everything.
 attrNameSnakeCase | Converts the attribute name to snake case. This is seen in the names matched by the pattern and the default format. For example, anAttrName to an\_attr\_name. Defaults to false.
-name     | The metric name to set. Capture groups from the `pattern` can be used. If not specified, the default format will be used. If it evaluates to empty, processing of this attribute stops with no output.
-value    | Value for the metric. Static values and capture groups from the `pattern` can be used. If not specified the scraped mBean value will be used.
-valueFactor | Optional number that `value` (or the scraped mBean value if `value` is not specified) is multiplied by, mainly used to convert mBean values from milliseconds to seconds.
-labels   | A map of label name to label value pairs. Capture groups from `pattern` can be used in each. `name` must be set to use this. Empty names and values are ignored. If not specified and the default format is not being used, no labels are set.
-help     | Help text for the metric. Capture groups from `pattern` can be used. `name` must be set to use this. Defaults to the mBean attribute description and the full name of the attribute.
-type     | The type of the metric, can be `GAUGE`, `COUNTER` or `UNTYPED`. `name` must be set to use this. Defaults to `UNTYPED`.
+name              | The metric name to set. Capture groups from the `pattern` can be used. If not specified, the default format will be used. If it evaluates to empty, processing of this attribute stops with no output.
+value             | Value for the metric. Static values and capture groups from the `pattern` can be used. If not specified the scraped mBean value will be used.
+valueFactor       | Optional number that `value` (or the scraped mBean value if `value` is not specified) is multiplied by, mainly used to convert mBean values from milliseconds to seconds.
+labels            | A map of label name to label value pairs. Capture groups from `pattern` can be used in each. `name` must be set to use this. Empty names and values are ignored. If not specified and the default format is not being used, no labels are set.
+help              | Help text for the metric. Capture groups from `pattern` can be used. `name` must be set to use this. Defaults to the mBean attribute description and the full name of the attribute.
+matchBeanValue    | Whether to append the bean value in the expression to match patterns against for this rule. (e.g: "beanName<beanType>: <beanValue>"). Defaults to `true`.
+cache             | Whether to cache bean name expressions to rule computation (match and mismatch). This can increase performance when collecting a lot of mbeans. Defaults to `false`.
+type              | The type of the metric, can be `GAUGE`, `COUNTER` or `UNTYPED`. `name` must be set to use this. Defaults to `UNTYPED`.
 
 Metric names and label names are sanitized. All characters other than `[a-zA-Z0-9:_]` are replaced with underscores,
 and adjacent underscores are collapsed. There's no limitations on label values or the help text.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ value             | Value for the metric. Static values and capture groups from 
 valueFactor       | Optional number that `value` (or the scraped mBean value if `value` is not specified) is multiplied by, mainly used to convert mBean values from milliseconds to seconds.
 labels            | A map of label name to label value pairs. Capture groups from `pattern` can be used in each. `name` must be set to use this. Empty names and values are ignored. If not specified and the default format is not being used, no labels are set.
 help              | Help text for the metric. Capture groups from `pattern` can be used. `name` must be set to use this. Defaults to the mBean attribute description and the full name of the attribute.
-cache             | Whether to cache bean name expressions to rule computation (match and mismatch). Not recommended for rules matching on bean value only the first value will be cached and re-used. This can increase performance when collecting a lot of mbeans. Defaults to `false`.
+cache             | Whether to cache bean name expressions to rule computation (match and mismatch). Not recommended for rules matching on bean value, as only the value from the first scrape will be cached and re-used. This can increase performance when collecting a lot of mbeans. Defaults to `false`.
 type              | The type of the metric, can be `GAUGE`, `COUNTER` or `UNTYPED`. `name` must be set to use this. Defaults to `UNTYPED`.
 
 Metric names and label names are sanitized. All characters other than `[a-zA-Z0-9:_]` are replaced with underscores,

--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -109,7 +109,7 @@ public class JmxCollector extends Collector implements Collector.Describable {
       }
     }
 
-    private synchronized Config getLastConfig() {
+    private synchronized Config getLatestConfig() {
       if (configFile != null) {
           long mtime = configFile.lastModified();
           if (mtime > config.lastUpdate) {
@@ -526,7 +526,7 @@ public class JmxCollector extends Collector implements Collector.Describable {
   public List<MetricFamilySamples> collect() {
       // Take a reference to the current config and collect with this one
       // (to avoid race conditions in case another thread reloads the config in the meantime)
-      Config config = getLastConfig();
+      Config config = getLatestConfig();
 
       MatchedRulesCache.StalenessTracker stalenessTracker = new MatchedRulesCache.StalenessTracker();
       Receiver receiver = new Receiver(config, stalenessTracker);

--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -399,8 +399,9 @@ public class JmxCollector extends Collector implements Collector.Describable {
           if (rule.cache) {
             MatchedRule cachedRule = cachedRules.get(rule, cacheKey);
             if (cachedRule != null) {
+              // add to the cache to signal that this cacheKey is not stale and should stay in the cache
               addToCache(rule, cacheKey, cachedRule);
-              if (!cachedRule.isUnmatched()) {
+              if (cachedRule.isMatched()) {
                 matchedRule = cachedRule;
                 break;
               }

--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -109,15 +109,13 @@ public class JmxCollector extends Collector implements Collector.Describable {
       }
     }
 
-    private Config maybeReloadConfig() {
+    private synchronized Config getLastConfig() {
       if (configFile != null) {
-        synchronized (this) {
           long mtime = configFile.lastModified();
           if (mtime > config.lastUpdate) {
             LOGGER.fine("Configuration file changed, reloading...");
             reloadConfig();
           }
-        }
       }
 
       return config;
@@ -528,7 +526,7 @@ public class JmxCollector extends Collector implements Collector.Describable {
   public List<MetricFamilySamples> collect() {
       // Take a reference to the current config and collect with this one
       // (to avoid race conditions in case another thread reloads the config in the meantime)
-      Config config = maybeReloadConfig();
+      Config config = getLastConfig();
 
       MatchedRulesCache.StalenessTracker stalenessTracker = new MatchedRulesCache.StalenessTracker();
       Receiver receiver = new Receiver(config, stalenessTracker);

--- a/collector/src/main/java/io/prometheus/jmx/MatchedRule.java
+++ b/collector/src/main/java/io/prometheus/jmx/MatchedRule.java
@@ -11,6 +11,7 @@ import java.util.List;
  */
 public class MatchedRule {
     final String name;
+    final String matchName;
     final Type type;
     final String help;
     final List<String> labelNames;
@@ -22,6 +23,7 @@ public class MatchedRule {
 
     private MatchedRule() {
         this.name = null;
+        this.matchName = null;
         this.type = null;
         this.help = null;
         this.labelNames = null;
@@ -32,6 +34,7 @@ public class MatchedRule {
 
     public MatchedRule(
             final String name,
+            final String matchName,
             final Type type,
             final String help,
             final List<String> labelNames,
@@ -39,6 +42,7 @@ public class MatchedRule {
             final Double value,
             double valueFactor) {
         this.name = name;
+        this.matchName = matchName;
         this.type = type;
         this.help = help;
         this.labelNames = labelNames;

--- a/collector/src/main/java/io/prometheus/jmx/MatchedRule.java
+++ b/collector/src/main/java/io/prometheus/jmx/MatchedRule.java
@@ -1,0 +1,62 @@
+package io.prometheus.jmx;
+
+import io.prometheus.client.Collector.Type;
+
+import java.util.List;
+
+/**
+ * MatchedRule is the result of matching a JMX bean against the rules present in the configuration file.
+ * As rules are matched using regular expressions, caching helps prevent having to match the same beans to the same list
+ * of regular expressions.
+ */
+public class MatchedRule {
+    final String name;
+    final Type type;
+    final String help;
+    final List<String> labelNames;
+    final List<String> labelValues;
+    final Double value;
+    final double valueFactor;
+
+    private static final MatchedRule _unmatched = new MatchedRule();
+
+    private MatchedRule() {
+        this.name = null;
+        this.type = null;
+        this.help = null;
+        this.labelNames = null;
+        this.labelValues = null;
+        this.value = null;
+        this.valueFactor = 1.0;
+    }
+
+    public MatchedRule(
+            final String name,
+            final Type type,
+            final String help,
+            final List<String> labelNames,
+            final List<String> labelValues,
+            final Double value,
+            double valueFactor) {
+        this.name = name;
+        this.type = type;
+        this.help = help;
+        this.labelNames = labelNames;
+        this.labelValues = labelValues;
+        this.value = value;
+        this.valueFactor = valueFactor;
+    }
+
+    /**
+     * A unmatched MatchedRule, used when no rule matching a JMX bean has been found in the configuration.
+     * Cached unmatched rules are still a cache hit, that will not produce any metric/value.
+     * @return the invalid rule
+     */
+    public static MatchedRule unmatched() {
+        return _unmatched;
+    }
+
+    public boolean isUnmatched() {
+        return this == _unmatched;
+    }
+}

--- a/collector/src/main/java/io/prometheus/jmx/MatchedRule.java
+++ b/collector/src/main/java/io/prometheus/jmx/MatchedRule.java
@@ -63,4 +63,8 @@ public class MatchedRule {
     public boolean isUnmatched() {
         return this == _unmatched;
     }
+
+    public boolean isMatched() {
+        return !isUnmatched();
+    }
 }

--- a/collector/src/main/java/io/prometheus/jmx/MatchedRulesCache.java
+++ b/collector/src/main/java/io/prometheus/jmx/MatchedRulesCache.java
@@ -1,7 +1,9 @@
 package io.prometheus.jmx;
 
-import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -10,40 +12,61 @@ import java.util.concurrent.ConcurrentHashMap;
  * matching against the same pattern in later bean collections.
  */
 public class MatchedRulesCache {
-    private final Map<Entry, MatchedRule> cachedRules;
+    private final Map<JmxCollector.Rule, Map<String, MatchedRule>> cachedRules;
 
     public MatchedRulesCache() {
-        this.cachedRules = new ConcurrentHashMap<Entry, MatchedRule>();
+        this.cachedRules = new ConcurrentHashMap<JmxCollector.Rule, Map<String, MatchedRule>>();
     }
 
     public void clear() {
         cachedRules.clear();
     }
 
-    public void put(final JmxCollector.Rule rule, final String name, final MatchedRule matchedRule) {
-        final Entry entry = new Entry(rule, name);
-        cachedRules.put(entry, matchedRule);
+    public void put(final JmxCollector.Rule rule, final String cacheKey, final MatchedRule matchedRule) {
+        Map<String, MatchedRule> cachedRulesForRule = cachedRules.get(rule);
+        if (cachedRulesForRule == null) {
+            synchronized (cachedRules) {
+                cachedRulesForRule = cachedRules.get(rule);
+                if (cachedRulesForRule == null) {
+                    cachedRulesForRule = new ConcurrentHashMap<String, MatchedRule>();
+                    cachedRules.put(rule, cachedRulesForRule);
+                }
+            }
+        }
+
+        cachedRulesForRule.put(cacheKey, matchedRule);
     }
 
-    public MatchedRule get(final JmxCollector.Rule rule, final String name) {
-        final Entry entry = new Entry(rule, name);
-        return cachedRules.get(entry);
+    public MatchedRule get(final JmxCollector.Rule rule, final String cacheKey) {
+        Map<String, MatchedRule> cachedRulesForRule = cachedRules.get(rule);
+        return (cachedRulesForRule == null) ? null : cachedRulesForRule.get(cacheKey);
     }
 
     // Remove stale rules (in the cache but not collected in the last run of the collector)
-    public void evictStaleEntries(Collection<Entry> lastCachedEntries) {
-        for (Entry entry : cachedRules.keySet()) {
-            if (!lastCachedEntries.contains(entry)) {
-                cachedRules.remove(entry);
+    public void evictStaleEntries(final LastEntries lastEntries) {
+        for (Map.Entry<JmxCollector.Rule, Map<String, MatchedRule>> entry : cachedRules.entrySet()) {
+            JmxCollector.Rule rule = entry.getKey();
+            Map<String, MatchedRule> cachedRulesForRule = entry.getValue();
+
+            for (String cacheKey : cachedRulesForRule.keySet()) {
+                if (!lastEntries.contains(rule, cacheKey)) {
+                    cachedRulesForRule.remove(cacheKey);
+                }
+            }
+
+            if (cachedRulesForRule.size() == 0) {
+                cachedRules.remove(rule);
             }
         }
     }
 
     public long matchedCount() {
         long count = 0;
-        for (MatchedRule matchedRule : cachedRules.values()) {
-            if (!matchedRule.isUnmatched()) {
-                count++;
+        for (Map<String, MatchedRule> matchedRules : cachedRules.values()) {
+            for (MatchedRule matchedRule : matchedRules.values()) {
+                if (matchedRule.isUnmatched()) {
+                    count++;
+                }
             }
         }
         return count;
@@ -51,43 +74,32 @@ public class MatchedRulesCache {
 
     public long unmatchedCount() {
         long count = 0;
-        for (MatchedRule matchedRule : cachedRules.values()) {
-            if (matchedRule.isUnmatched()) {
-                count++;
+        for (Map<String, MatchedRule> matchedRules : cachedRules.values()) {
+            for (MatchedRule matchedRule : matchedRules.values()) {
+                if (matchedRule.isUnmatched()) {
+                    count++;
+                }
             }
         }
         return count;
     }
 
-    public static class Entry {
-        public final JmxCollector.Rule rule;
-        public final String name;
+    public static class LastEntries {
+        final Map<JmxCollector.Rule, Set<String>> lastCachedEntries = new HashMap<JmxCollector.Rule, Set<String>>();
 
-        public Entry(final JmxCollector.Rule rule, final String name) {
-            this.rule = rule;
-            this.name = name;
-        }
-
-        @Override
-        public int hashCode() {
-            int result = 17;
-            result = 31 * result + rule.hashCode();
-            result = 31 * result + name.hashCode();
-            return result;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj == this) {
-                return true;
+        public void add(final JmxCollector.Rule rule, final String cacheKey) {
+            Set<String> lastCachedEntriesForRule = lastCachedEntries.get(rule);
+            if (lastCachedEntriesForRule == null) {
+                lastCachedEntriesForRule = new HashSet<String>();
+                lastCachedEntries.put(rule, lastCachedEntriesForRule);
             }
 
-            if (!(obj instanceof Entry)) {
-                return false;
-            }
+            lastCachedEntriesForRule.add(cacheKey);
+        }
 
-            Entry entry = (Entry) obj;
-            return rule.equals(entry.rule) && name.equals(entry.name);
+        public boolean contains(final JmxCollector.Rule rule, final String cacheKey) {
+            Set<String> lastCachedEntriesForRule = lastCachedEntries.get(rule);
+            return (lastCachedEntriesForRule != null) && lastCachedEntriesForRule.contains(cacheKey);
         }
     }
 }

--- a/collector/src/main/java/io/prometheus/jmx/MatchedRulesCache.java
+++ b/collector/src/main/java/io/prometheus/jmx/MatchedRulesCache.java
@@ -1,0 +1,93 @@
+package io.prometheus.jmx;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * MatchedRulesCache is a cache for bean name to configured rule mapping (See JmxCollector.Receiver).
+ * The cache also retains unmatched entries (a bean name not matching a rule pattern) to avoid
+ * matching against the same pattern in later bean collections.
+ */
+public class MatchedRulesCache {
+    private final Map<Entry, MatchedRule> cachedRules;
+
+    public MatchedRulesCache() {
+        this.cachedRules = new ConcurrentHashMap<Entry, MatchedRule>();
+    }
+
+    public void clear() {
+        cachedRules.clear();
+    }
+
+    public void put(final JmxCollector.Rule rule, final String name, final MatchedRule matchedRule) {
+        final Entry entry = new Entry(rule, name);
+        cachedRules.put(entry, matchedRule);
+    }
+
+    public MatchedRule get(final JmxCollector.Rule rule, final String name) {
+        final Entry entry = new Entry(rule, name);
+        return cachedRules.get(entry);
+    }
+
+    // Remove stale rules (in the cache but not collected in the last run of the collector)
+    public void evictStaleEntries(Collection<Entry> lastCachedEntries) {
+        for (Entry entry : cachedRules.keySet()) {
+            if (!lastCachedEntries.contains(entry)) {
+                cachedRules.remove(entry);
+            }
+        }
+    }
+
+    public long matchedCount() {
+        long count = 0;
+        for (MatchedRule matchedRule : cachedRules.values()) {
+            if (!matchedRule.isUnmatched()) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    public long unmatchedCount() {
+        long count = 0;
+        for (MatchedRule matchedRule : cachedRules.values()) {
+            if (matchedRule.isUnmatched()) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    public static class Entry {
+        public final JmxCollector.Rule rule;
+        public final String name;
+
+        public Entry(final JmxCollector.Rule rule, final String name) {
+            this.rule = rule;
+            this.name = name;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = 17;
+            result = 31 * result + rule.hashCode();
+            result = 31 * result + name.hashCode();
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+
+            if (!(obj instanceof Entry)) {
+                return false;
+            }
+
+            Entry entry = (Entry) obj;
+            return rule.equals(entry.rule) && name.equals(entry.name);
+        }
+    }
+}

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -272,18 +272,6 @@ public class JmxCollectorTest {
     }
 
     @Test
-    public void testMatchBeanValueDisabled() throws Exception {
-        JmxCollector jc = new JmxCollector("\n---\nrules:\n- pattern: `.*:`\n  name: foo\n  matchBeanValue: false".replace('`','"')).register(registry);
-        assertNull(registry.getSampleValue("foo", new String[]{}, new String[]{}));
-    }
-
-    @Test
-    public void testMatchBeanValueEnabled() throws Exception {
-        JmxCollector jc = new JmxCollector("\n---\nrules:\n- pattern: `.*:`\n  name: foo\n  matchBeanValue: true".replace('`','"')).register(registry);
-        assertNotNull(registry.getSampleValue("foo", new String[]{}, new String[]{}));
-    }
-
-    @Test
     public void testCachedBeansDisabled() throws Exception {
         JmxCollector jc = new JmxCollector("\n---\nrules:\n- pattern: `.*`\n  name: foo\n  value: 1\n  valueFactor: 4".replace('`','"')).register(registry);
         assertEquals(0.0, registry.getSampleValue("jmx_scrape_cache_matched_beans", new String[]{}, new String[]{}), .001);

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -274,14 +274,14 @@ public class JmxCollectorTest {
     @Test
     public void testCachedBeansDisabled() throws Exception {
         JmxCollector jc = new JmxCollector("\n---\nrules:\n- pattern: `.*`\n  name: foo\n  value: 1\n  valueFactor: 4".replace('`','"')).register(registry);
-        assertEquals(0.0, registry.getSampleValue("jmx_scrape_cache_matched_beans", new String[]{}, new String[]{}), .001);
+        assertEquals(0.0, registry.getSampleValue("jmx_scrape_cached_beans", new String[]{}, new String[]{}), .001);
         assertEquals(4.0, registry.getSampleValue("foo", new String[]{}, new String[]{}), .001);
     }
 
     @Test
     public void testCachedBeansEnabled() throws Exception {
         JmxCollector jc = new JmxCollector("\n---\nrules:\n- pattern: `.*`\n  name: foo\n  value: 1\n  valueFactor: 4\n  cache: true".replace('`','"')).register(registry);
-        assertTrue(registry.getSampleValue("jmx_scrape_cache_matched_beans", new String[]{}, new String[]{}) > 0);
+        assertTrue(registry.getSampleValue("jmx_scrape_cached_beans", new String[]{}, new String[]{}) > 0);
         assertEquals(4.0, registry.getSampleValue("foo", new String[]{}, new String[]{}), .001);
     }
 }

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -1,18 +1,19 @@
 package io.prometheus.jmx;
 
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.lang.management.ManagementFactory;
+import javax.management.MBeanServer;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import io.prometheus.client.Collector;
-import io.prometheus.client.CollectorRegistry;
-import java.lang.management.ManagementFactory;
-import javax.management.MBeanServer;
-import org.junit.Test;
-import org.junit.Before;
-import org.junit.BeforeClass;
-
 
 public class JmxCollectorTest {
 
@@ -268,5 +269,19 @@ public class JmxCollectorTest {
       JmxCollector jc = new JmxCollector(rulePattern).register(registry);
       Double actual = registry.getSampleValue("org_apache_camel_LastExchangeFailureTimestamp", new String[]{"context", "route", "type"}, new String[]{"my-camel-context", "my-route-name", "routes"});
       assertEquals(Camel.EXPECTED_SECONDS, actual, 0);
+    }
+
+    @Test
+    public void testCachedBeansDisabled() throws Exception {
+        JmxCollector jc = new JmxCollector("\n---\nrules:\n- pattern: `.*`\n  name: foo\n  value: 1\n  valueFactor: 4".replace('`','"')).register(registry);
+        assertNull(registry.getSampleValue("jmx_scrape_cached_beans", new String[]{}, new String[]{}));
+        assertEquals(4.0, registry.getSampleValue("foo", new String[]{}, new String[]{}), .001);
+    }
+
+    @Test
+    public void testCachedBeansEnabled() throws Exception {
+        JmxCollector jc = new JmxCollector("\n---\ncacheRules: true\nrules:\n- pattern: `.*`\n  name: foo\n  value: 1\n  valueFactor: 4".replace('`','"')).register(registry);
+        assertTrue(registry.getSampleValue("jmx_scrape_cached_beans", new String[]{}, new String[]{}) > 0);
+        assertEquals(4.0, registry.getSampleValue("foo", new String[]{}, new String[]{}), .001);
     }
 }

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -272,16 +272,28 @@ public class JmxCollectorTest {
     }
 
     @Test
+    public void testMatchBeanValueDisabled() throws Exception {
+        JmxCollector jc = new JmxCollector("\n---\nrules:\n- pattern: `.*:`\n  name: foo\n  matchBeanValue: false".replace('`','"')).register(registry);
+        assertNull(registry.getSampleValue("foo", new String[]{}, new String[]{}));
+    }
+
+    @Test
+    public void testMatchBeanValueEnabled() throws Exception {
+        JmxCollector jc = new JmxCollector("\n---\nrules:\n- pattern: `.*:`\n  name: foo\n  matchBeanValue: true".replace('`','"')).register(registry);
+        assertNotNull(registry.getSampleValue("foo", new String[]{}, new String[]{}));
+    }
+
+    @Test
     public void testCachedBeansDisabled() throws Exception {
         JmxCollector jc = new JmxCollector("\n---\nrules:\n- pattern: `.*`\n  name: foo\n  value: 1\n  valueFactor: 4".replace('`','"')).register(registry);
-        assertNull(registry.getSampleValue("jmx_scrape_cached_beans", new String[]{}, new String[]{}));
+        assertEquals(0.0, registry.getSampleValue("jmx_scrape_cache_matched_beans", new String[]{}, new String[]{}), .001);
         assertEquals(4.0, registry.getSampleValue("foo", new String[]{}, new String[]{}), .001);
     }
 
     @Test
     public void testCachedBeansEnabled() throws Exception {
-        JmxCollector jc = new JmxCollector("\n---\ncacheRules: true\nrules:\n- pattern: `.*`\n  name: foo\n  value: 1\n  valueFactor: 4".replace('`','"')).register(registry);
-        assertTrue(registry.getSampleValue("jmx_scrape_cached_beans", new String[]{}, new String[]{}) > 0);
+        JmxCollector jc = new JmxCollector("\n---\nrules:\n- pattern: `.*`\n  name: foo\n  value: 1\n  valueFactor: 4\n  cache: true\n  matchBeanValue: true".replace('`','"')).register(registry);
+        assertTrue(registry.getSampleValue("jmx_scrape_cache_matched_beans", new String[]{}, new String[]{}) > 0);
         assertEquals(4.0, registry.getSampleValue("foo", new String[]{}, new String[]{}), .001);
     }
 }

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -280,7 +280,7 @@ public class JmxCollectorTest {
 
     @Test
     public void testCachedBeansEnabled() throws Exception {
-        JmxCollector jc = new JmxCollector("\n---\nrules:\n- pattern: `.*`\n  name: foo\n  value: 1\n  valueFactor: 4\n  cache: true\n  matchBeanValue: true".replace('`','"')).register(registry);
+        JmxCollector jc = new JmxCollector("\n---\nrules:\n- pattern: `.*`\n  name: foo\n  value: 1\n  valueFactor: 4\n  cache: true".replace('`','"')).register(registry);
         assertTrue(registry.getSampleValue("jmx_scrape_cache_matched_beans", new String[]{}, new String[]{}) > 0);
         assertEquals(4.0, registry.getSampleValue("foo", new String[]{}, new String[]{}), .001);
     }


### PR DESCRIPTION
This improves performance for some use cases.

The exporter is configured with a set of rules to match regular
expressions against bean names. Regular expressions can be CPU-intensive,
and matching the same bean names over the same patterns is
time-consuming when there are tens of thousands of bean names (e.g:
exposed by Kafka). Using a single `ConcurrentHashMap` to store the result
of pattern matching here.

The `MatchedRule` class was introduced here to "store" this result.
Each rule in the configuration leads to a `MatchedRule` which helps
build the set of metrics to expose to Prometheus.
The mapping between a bean name + attributes to a `MatchedRule` is
done once. Some (in Kafka, most) bean names may not match any rule,
so caching of `MatchedRule.unmatched()` helps prevent re-computation
of bean names to non-existent rules.

The logic to map a bean name to a Prometheus MetricFamilySample is
unchanged from the upstream, the `MatchedRule` was introduced only to
be able to cache the results.

Caching is disabled by default (behaviour unchanged), and can be enabled
by setting `cacheRules: true` in the configuration.

-----

In our case, this lead to reducing collection time from ~70 sec to ~3 sec on
some of our applications (Kafka brokers). I opened [a thread](https://groups.google.com/g/prometheus-developers/c/RNpcNOPwyeE) on the mailing list
a couple of weeks ago and haven't heard back, but definitely happy to discuss
and make changes if needed, if you think this is worth merging. 🙂