### PR TITLE
Upgrade java source to java 8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
               <artifactId>maven-compiler-plugin</artifactId>
               <version>2.3.2</version>
               <configuration>
-                  <source>1.6</source>
-                  <target>1.6</target>
+                  <source>1.8</source>
+                  <target>1.8</target>
               </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
Java 6 support ended in Dec 2018. https://en.wikipedia.org/wiki/Java_version_history

Could we move this project to Java 8 source?

The driver here is that newer versions of the java compiler simply don't support the old source versions, so this project won't build out-of-the-box with a Java 13 JDK (for example).

Thanks!