### PR TITLE
Performance improvements

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -512,12 +513,12 @@ public class JmxCollector extends Collector implements Collector.Describable {
         } else if (beanValue instanceof Boolean) {
           value = (Boolean) beanValue ? 1 : 0;
         } else {
-          LOGGER.fine("Ignoring unsupported bean: " + beanName + attrName + ": " + beanValue);
+            if (LOGGER.isLoggable(Level.FINE)) LOGGER.fine("Ignoring unsupported bean: " + beanName + attrName + ": " + beanValue);
           return;
         }
 
         // Add to samples.
-        LOGGER.fine("add metric sample: " + matchedRule.name + " " + matchedRule.labelNames + " " + matchedRule.labelValues + " " + value.doubleValue());
+        if (LOGGER.isLoggable(Level.FINE)) LOGGER.fine("add metric sample: " + matchedRule.name + " " + matchedRule.labelNames + " " + matchedRule.labelValues + " " + value.doubleValue());
         addSample(new MetricFamilySamples.Sample(matchedRule.name, matchedRule.labelNames, matchedRule.labelValues, value.doubleValue()), matchedRule.type, help);
       }
 

--- a/collector/src/main/java/io/prometheus/jmx/JmxMBeanPropertyCache.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxMBeanPropertyCache.java
@@ -2,6 +2,7 @@ package io.prometheus.jmx;
 
 import javax.management.MBeanAttributeInfo;
 import javax.management.ObjectName;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -14,6 +15,24 @@ import java.util.regex.Pattern;
  * the frequency with which we invoke PROPERTY_PATTERN when discovering mBeans.
  */
 class JmxMBeanPropertyCache {
+    /**
+     * Encapsulates attribute info with other data.
+     */
+    public static class MBeanAttributeInfoWrapper {
+        MBeanAttributeInfo info;
+        boolean usedAtLastScrape;
+        public MBeanAttributeInfoWrapper(MBeanAttributeInfo info) {
+            this.info = info;
+            this.usedAtLastScrape = true;
+        }
+        public boolean isUsedAtLastScrape() {
+            return usedAtLastScrape;
+        }
+        public void setUsedAtLastScrape(boolean activated) {
+            this.usedAtLastScrape = activated;
+        }
+    }
+
     private static final Pattern PROPERTY_PATTERN = Pattern.compile(
             "([^,=:\\*\\?]+)" + // Name - non-empty, anything but comma, equals, colon, star, or question mark
                     "=" +  // Equals
@@ -33,9 +52,8 @@ class JmxMBeanPropertyCache {
     // in the order they were added).
     private final Map<ObjectName, LinkedHashMap<String, String>> keyPropertiesPerBean;
 
-
-    private final Map<ObjectName, Map<String, MBeanAttributeInfo>> mbeanInfoCache = 
-            new ConcurrentHashMap<ObjectName, Map<String,MBeanAttributeInfo>>();
+    private final Map<ObjectName, Map<String, MBeanAttributeInfoWrapper>> mbeanInfoCache = 
+            new ConcurrentHashMap<ObjectName, Map<String,MBeanAttributeInfoWrapper>>();
 
     public JmxMBeanPropertyCache() {
         this.keyPropertiesPerBean = new ConcurrentHashMap<ObjectName, LinkedHashMap<String, String>>();
@@ -70,7 +88,7 @@ class JmxMBeanPropertyCache {
      * @param mbeanName
      * @param name2AttrInfo
      */
-    public void cacheAttrInfo(ObjectName mbeanName, Map<String, MBeanAttributeInfo> name2AttrInfo) {
+    public void cacheAttrInfo(ObjectName mbeanName, Map<String, MBeanAttributeInfoWrapper> name2AttrInfo) {
         mbeanInfoCache.put(mbeanName, name2AttrInfo);
     }
 
@@ -80,7 +98,7 @@ class JmxMBeanPropertyCache {
      * @param mbeanName
      * @return Map or attributes names to attributes info
      */
-    public Map<String, MBeanAttributeInfo> getAttrInfo(ObjectName mbeanName) {
+    public Map<String, MBeanAttributeInfoWrapper> getAttrInfo(ObjectName mbeanName) {
         return mbeanInfoCache.get(mbeanName);
     }
 

--- a/collector/src/main/java/io/prometheus/jmx/MatchedRulesCache.java
+++ b/collector/src/main/java/io/prometheus/jmx/MatchedRulesCache.java
@@ -3,6 +3,7 @@ package io.prometheus.jmx;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,9 +38,10 @@ public class MatchedRulesCache {
             JmxCollector.Rule rule = entry.getKey();
             Map<String, MatchedRule> cachedRulesForRule = entry.getValue();
 
-            for (String cacheKey : cachedRulesForRule.keySet()) {
-                if (!stalenessTracker.contains(rule, cacheKey)) {
-                    cachedRulesForRule.remove(cacheKey);
+            Iterator<String> it = cachedRulesForRule.keySet().iterator();
+            while (it.hasNext()) {
+                if (!stalenessTracker.contains(rule, it.next())) {
+                    it.remove();
                 }
             }
         }


### PR DESCRIPTION
Hi @brian-brazil,

This PR regroups 4 commits, each of them allowing to optimize a little the exporter code.
The first 3 can not change the behavior.
The last commit, about MBeanInfo caching, could have impact. I don't think a MBeanInfo should change, but if you think this can happen may be a configuration param could allow to deactivate.

Please tell me what you think.