### PR TITLE
Roll back snakeyaml version from 1.26 to 1.16 to fix java 6 support

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -29,7 +29,8 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.26</version>
+      <!-- uses an older version because 2.24+ requires Java 7 -->
+      <version>1.16</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Snakeyaml dropped support for java 6 from 2.14+, so we revert back to an earlier version to maintain java 6 support.