### PR TITLE
java.lang.ClassCastException: javax.management.openmbean.TabularDataSupport cannot be cast to javax.management.Attribute

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -157,18 +157,22 @@ class JmxScraper {
             logScrape(mbeanName, name2AttrInfo.keySet(), "Fail: " + e);
             return;
         }
-        for (Attribute attribute : attributes.asList()) {
-            MBeanAttributeInfo attr = name2AttrInfo.get(attribute.getName());
-            logScrape(mbeanName, attr, "process");
-            processBeanValue(
-                    mbeanName.getDomain(),
-                    jmxMBeanPropertyCache.getKeyPropertyList(mbeanName),
-                    new LinkedList<String>(),
-                    attr.getName(),
-                    attr.getType(),
-                    attr.getDescription(),
-                    attribute.getValue()
-            );
+        
+        for (Object attributeObj : attributes.asList()) {
+            if (Attribute.class.isInstance(attributeObj)) {
+                Attribute attribute = (Attribute)(attributeObj);
+                MBeanAttributeInfo attr = name2AttrInfo.get(attribute.getName());
+                logScrape(mbeanName, attr, "process");
+                processBeanValue(
+                        mbeanName.getDomain(),
+                        jmxMBeanPropertyCache.getKeyPropertyList(mbeanName),
+                        new LinkedList<String>(),
+                        attr.getName(),
+                        attr.getType(),
+                        attr.getDescription(),
+                        attribute.getValue()
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Refactored the Scraper to ensure that when processing the list of Attributes, only instances that are of type javax.management.Attribute will be parsed. This will avoid ClassCastException errors when an entry is of type javax.management.openmbean.TabularDataSupport (Typical cases exist in Apache Ignite)