### PR TITLE
SEVERE: JMX scrape failed: java.lang.ClassCastException: javax.management.openmbean.TabularDataSupport cannot be cast to javax.management.Attribute

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -157,18 +157,21 @@ class JmxScraper {
             logScrape(mbeanName, name2AttrInfo.keySet(), "Fail: " + e);
             return;
         }
-        for (Attribute attribute : attributes.asList()) {
-            MBeanAttributeInfo attr = name2AttrInfo.get(attribute.getName());
-            logScrape(mbeanName, attr, "process");
-            processBeanValue(
-                    mbeanName.getDomain(),
-                    jmxMBeanPropertyCache.getKeyPropertyList(mbeanName),
-                    new LinkedList<String>(),
-                    attr.getName(),
-                    attr.getType(),
-                    attr.getDescription(),
-                    attribute.getValue()
-            );
+        for (Object attributeObj : attributes.asList()) {
+            if (Attribute.class.isInstance(attributeObj)) {
+                Attribute attribute = (Attribute)(attributeObj);
+                MBeanAttributeInfo attr = name2AttrInfo.get(attribute.getName());
+                logScrape(mbeanName, attr, "process");
+                processBeanValue(
+                        mbeanName.getDomain(),
+                        jmxMBeanPropertyCache.getKeyPropertyList(mbeanName),
+                        new LinkedList<String>(),
+                        attr.getName(),
+                        attr.getType(),
+                        attr.getDescription(),
+                        attribute.getValue()
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Added a sanitary check to the JMX Scraper so that it will skip Attributes processing that are not javax.management.Attribute types. This is an issue present in Apache Ignite, when there are some Attributes that are of type javax.management.openmbean.TabularDataSupport

Signed-off-by: Neville Bonavia <neville.bonavia@gig.com>

The error log in such a situation is: -
Oct 08, 2020 1:28:28 PM io.prometheus.jmx.JmxCollector collect
SEVERE: JMX scrape failed: java.lang.ClassCastException: javax.management.openmbean.TabularDataSupport cannot be cast to javax.management.Attribute
    at io.prometheus.jmx.JmxScraper.scrapeBean(JmxScraper.java:163)
    at io.prometheus.jmx.JmxScraper.doScrape(JmxScraper.java:117)
    at io.prometheus.jmx.JmxCollector.collect(JmxCollector.java:542)
    at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.findNextElement(CollectorRegistry.java:190)
    at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.nextElement(CollectorRegistry.java:223)
    at io.prometheus.client.CollectorRegistry$MetricFamilySamplesEnumeration.nextElement(CollectorRegistry.java:144)
    at io.prometheus.client.exporter.common.TextFormat.write004(TextFormat.java:22)
    at io.prometheus.client.exporter.HTTPServer$HTTPMetricHandler.handle(HTTPServer.java:68)
    at com.sun.net.httpserver.Filter$Chain.doFilter(Filter.java:79)
    at sun.net.httpserver.AuthFilter.doFilter(AuthFilter.java:83)
    at com.sun.net.httpserver.Filter$Chain.doFilter(Filter.java:82)
    at sun.net.httpserver.ServerImpl$Exchange$LinkHandler.handle(ServerImpl.java:675)
    at com.sun.net.httpserver.Filter$Chain.doFilter(Filter.java:79)
    at sun.net.httpserver.ServerImpl$Exchange.run(ServerImpl.java:647)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)