### PR TITLE
updated spark example config for spark 3.0

### DIFF
--- a/example_configs/spark-3-0.yml
+++ b/example_configs/spark-3-0.yml
@@ -2,17 +2,17 @@ rules:
 
   # These come from the master
   # Example: master.aliveWorkers
-  - pattern: "metrics<name=master\\.(.*)><>Value"
+  - pattern: "metrics<name=master\\.(.*), type=counters><>Value"
     name: spark_master_$1
 
   # These come from the worker
   # Example: worker.coresFree
-  - pattern: "metrics<name=worker\\.(.*)><>Value"
+  - pattern: "metrics<name=worker\\.(.*), type=counters><>Value"
     name: spark_worker_$1
 
   # These come from the application driver
   # Example: app-20160809000059-0000.driver.DAGScheduler.stage.failedStages
-  - pattern: "metrics<name=(.*)\\.driver\\.(DAGScheduler|BlockManager|jvm)\\.(.*)><>Value"
+  - pattern: "metrics<name=(.*)\\.driver\\.(DAGScheduler|BlockManager|jvm)\\.(.*), type=gauges><>Value"
     name: spark_driver_$2_$3
     type: GAUGE
     labels:
@@ -20,13 +20,13 @@ rules:
 
   # These come from the application driver
   # Emulate timers for DAGScheduler like messagePRocessingTime
-  - pattern: "metrics<name=(.*)\\.driver\\.DAGScheduler\\.(.*)><>Count"
+  - pattern: "metrics<name=(.*)\\.driver\\.DAGScheduler\\.(.*), type=counters><>Count"
     name: spark_driver_DAGScheduler_$2_total
     type: COUNTER
     labels:
       app_id: "$1"
 
-  - pattern: "metrics<name=(.*)\\.driver\\.HiveExternalCatalog\\.(.*)><>Count"
+  - pattern: "metrics<name=(.*)\\.driver\\.HiveExternalCatalog\\.(.*), type=counters><>Count"
     name: spark_driver_HiveExternalCatalog_$2_total
     type: COUNTER
     labels:
@@ -34,7 +34,7 @@ rules:
 
   # These come from the application driver
   # Emulate histograms for CodeGenerator
-  - pattern: "metrics<name=(.*)\\.driver\\.CodeGenerator\\.(.*)><>Count"
+  - pattern: "metrics<name=(.*)\\.driver\\.CodeGenerator\\.(.*), type=counters><>Count"
     name: spark_driver_CodeGenerator_$2_total
     type: COUNTER
     labels:
@@ -42,14 +42,14 @@ rules:
 
   # These come from the application driver
   # Emulate timer (keep only count attribute) plus counters for LiveListenerBus
-  - pattern: "metrics<name=(.*)\\.driver\\.LiveListenerBus\\.(.*)><>Count"
+  - pattern: "metrics<name=(.*)\\.driver\\.LiveListenerBus\\.(.*), type=counters><>Count"
     name: spark_driver_LiveListenerBus_$2_total
     type: COUNTER
     labels:
       app_id: "$1"
 
   # Get Gauge type metrics for LiveListenerBus
-  - pattern: "metrics<name=(.*)\\.driver\\.LiveListenerBus\\.(.*)><>Value"
+  - pattern: "metrics<name=(.*)\\.driver\\.LiveListenerBus\\.(.*), type=gauges><>Value"
     name: spark_driver_LiveListenerBus_$2
     type: GAUGE
     labels:
@@ -57,7 +57,7 @@ rules:
 
   # These come from the application driver if it's a streaming application
   # Example: app-20160809000059-0000.driver.com.example.ClassName.StreamingMetrics.streaming.lastCompletedBatch_schedulingDelay
-  - pattern: "metrics<name=(.*)\\.driver\\.(.*)\\.StreamingMetrics\\.streaming\\.(.*)><>Value"
+  - pattern: "metrics<name=(.*)\\.driver\\.(.*)\\.StreamingMetrics\\.streaming\\.(.*), type=gauges><>Value"
     name: spark_driver_streaming_$3
     labels:
       app_id: "$1"
@@ -65,7 +65,7 @@ rules:
 
   # These come from the application driver if it's a structured streaming application
   # Example: app-20160809000059-0000.driver.spark.streaming.QueryName.inputRate-total
-  - pattern: "metrics<name=(.*)\\.driver\\.spark\\.streaming\\.(.*)\\.(.*)><>Value"
+  - pattern: "metrics<name=(.*)\\.driver\\.spark\\.streaming\\.(.*)\\.(.*), type=gauges><>Value"
     name: spark_driver_structured_streaming_$3
     labels:
       app_id: "$1"
@@ -77,37 +77,44 @@ rules:
   #  app-20160809000059-0000.0.executor.JvmGCtime (counter)
 
   # filesystem metrics are declared as gauge metrics, but are actually counters
-  - pattern: "metrics<name=(.*)\\.(.*)\\.executor\\.filesystem\\.(.*)><>Value"
+  - pattern: "metrics<name=(.*)\\.(.*)\\.executor\\.filesystem\\.(.*), type=gauges><>Value"
     name: spark_executor_filesystem_$3_total
     type: COUNTER
     labels:
       app_id: "$1"
       executor_id: "$2"
 
-  - pattern: "metrics<name=(.*)\\.(.*)\\.executor\\.(.*)><>Value"
+  - pattern: "metrics<name=(.*)\\.(.*)\\.executor\\.(.*), type=gauges><>Value"
     name: spark_executor_$3
     type: GAUGE
     labels:
       app_id: "$1"
       executor_id: "$2"
 
-  - pattern: "metrics<name=(.*)\\.(.*)\\.executor\\.(.*)><>Count"
+  - pattern: "metrics<name=(.*)\\.(.*)\\.executor\\.(.*), type=counters><>Count"
     name: spark_executor_$3_total
     type: COUNTER
     labels:
       app_id: "$1"
       executor_id: "$2"
 
+  - pattern: "metrics<name=(.*)\\.(.*)\\.ExecutorMetrics\\.(.*), type=gauges><>Value"
+    name: spark_executor_$3
+    type: GAUGE
+    labels:
+      app_id: "$1"
+      executor_id: "$2"
+
   # These come from the application executors
   # Example: app-20160809000059-0000.0.jvm.threadpool.activeTasks
-  - pattern: "metrics<name=(.*)\\.([0-9]+)\\.(jvm|NettyBlockTransfer)\\.(.*)><>Value"
+  - pattern: "metrics<name=(.*)\\.([0-9]+)\\.(jvm|NettyBlockTransfer)\\.(.*), type=gauges><>Value"
     name: spark_executor_$3_$4
     type: GAUGE
     labels:
       app_id: "$1"
       executor_id: "$2"
 
-  - pattern: "metrics<name=(.*)\\.([0-9]+)\\.HiveExternalCatalog\\.(.*)><>Count"
+  - pattern: "metrics<name=(.*)\\.([0-9]+)\\.HiveExternalCatalog\\.(.*), type=counters><>Count"
     name: spark_executor_HiveExternalCatalog_$3_total
     type: COUNTER
     labels:
@@ -116,7 +123,7 @@ rules:
 
   # These come from the application driver
   # Emulate histograms for CodeGenerator
-  - pattern: "metrics<name=(.*)\\.([0-9]+)\\.CodeGenerator\\.(.*)><>Count"
+  - pattern: "metrics<name=(.*)\\.([0-9]+)\\.CodeGenerator\\.(.*), type=counters><>Count"
     name: spark_executor_CodeGenerator_$3_total
     type: COUNTER
     labels:


### PR DESCRIPTION
- added "type" value to Regex so resulting prometheus metrics are identical to spark 2.4 version

@brian-brazil 

i don't know the details, but it seems that a "type=counters" or "type=gauge" has been added to the JMX metrics of spark in 3.0 version.
So i added this type strings to the regex to emit this value from the resulting prometheus metric name so we have a config for spark 2.4 and 3.0 resulting in the same metric names.