### PR TITLE
Code to reset the MBean metrics after each scrape

### DIFF
--- a/example_configs/resetMetrics_example.yml
+++ b/example_configs/resetMetrics_example.yml
@@ -1,0 +1,11 @@
+# other config sections
+
+resetMetrics: true
+MBeansToReset:
+  - "com.testsoftware:*,name=test.util.internal.mbean.testServerMBean"
+  - "com.testsoftware:*,name=test.util.cache.internal.mbean.testCacheStatsMBean"
+  - "com.testsoftware:*,name=test.util.jmx.internal.mbeans.runandrecord.testRunAndRecordStatsMBean"
+
+
+# subsequent config sections......
+#rules:


### PR DESCRIPTION
We had a project requirement to reset the metrics on the MBeans each time we scrape in order to avoid any smoothing affect of the averages reported over time. This is the code we used to achieve that, the ability to turn the functionality on/off as well as the list of MBeans to enable this functionality for is controllable via the config yml file