### PR TITLE
Update to client_java 0.10.0 and OpenMetrics.

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
-      <version>0.9.0</version>
+      <version>0.10.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.26</version>
+      <version>1.23</version>
     </dependency>
   </dependencies>
 

--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -46,7 +46,7 @@ public class JmxCollector extends Collector implements Collector.Describable {
       String help;
       boolean attrNameSnakeCase;
       boolean cache = false;
-      Type type = Type.UNTYPED;
+      Type type = Type.UNKNOWN;
       ArrayList<String> labelNames;
       ArrayList<String> labelValues;
     }
@@ -210,7 +210,12 @@ public class JmxCollector extends Collector implements Collector.Describable {
               rule.cache = (Boolean)yamlRule.get("cache");
             }
             if (yamlRule.containsKey("type")) {
-              rule.type = Type.valueOf((String)yamlRule.get("type"));
+              String t = (String)yamlRule.get("type");
+              // Gracefully handle switch to OM data model.
+              if ("UNTYPED".equals(t)) {
+                t = "UNKNOWN";
+              }
+              rule.type = Type.valueOf(t);
             }
             if (yamlRule.containsKey("help")) {
               rule.help = (String)yamlRule.get("help");

--- a/jmx_prometheus_httpserver/pom.xml
+++ b/jmx_prometheus_httpserver/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
-      <version>0.9.0</version>
+      <version>0.10.0</version>
     </dependency>
   </dependencies>
 

--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -23,12 +23,12 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_hotspot</artifactId>
-      <version>0.9.0</version>
+      <version>0.10.0</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
-      <version>0.9.0</version>
+      <version>0.10.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Transparently handle the UNTYPED->UNKNOWN switch for users.

Change snakeyaml version to 1.23 so Java 6 works again, fixes #537.

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>