### PR TITLE
Change maintainer from @brian-brazil to @fstab and @tomwilkie

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,1 +1,2 @@
-* Brian Brazil <brian.brazil@robustperception.io>
+* Fabian Stäber <fabian@fstab.de> @fstab
+* Tom Wilkie <tom@grafana.com> @tomwilkie


### PR DESCRIPTION
Yesterday at the dev-summit, the Prometheus team has proposed @fstab and @tomwilkie as the new maintainer for this repo after @brian-brazil's retirement from the project.

This change will only be merged after an announcement on the prometheus-developers mailing list and is subject to lazy consensus.

Thank you, @brian-brazil, for the incredible amount of work done in this repository and for the project in general.