### PR TITLE
Process JMX beans with an ArrayList value

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -20,14 +20,7 @@ import javax.naming.Context;
 import javax.rmi.ssl.SslRMIClientSocketFactory;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -157,27 +150,21 @@ class JmxScraper {
             logScrape(mbeanName, name2AttrInfo.keySet(), "Fail: " + e);
             return;
         }
-        try {
-            for (Object attributeObj : attributes.asList()) {
-                if (Attribute.class.isInstance(attributeObj)) {
-                    Attribute attribute = (Attribute)(attributeObj);
-                    MBeanAttributeInfo attr = name2AttrInfo.get(attribute.getName());
-                    logScrape(mbeanName, attr, "process");
-                    processBeanValue(
-                            mbeanName.getDomain(),
-                            jmxMBeanPropertyCache.getKeyPropertyList(mbeanName),
-                            new LinkedList<String>(),
-                            attr.getName(),
-                            attr.getType(),
-                            attr.getDescription(),
-                            attribute.getValue()
-                    );
-                }
+        for (Object attributeObj : attributes) {
+            if (Attribute.class.isInstance(attributeObj)) {
+                Attribute attribute = (Attribute)(attributeObj);
+                MBeanAttributeInfo attr = name2AttrInfo.get(attribute.getName());
+                logScrape(mbeanName, attr, "process");
+                processBeanValue(
+                        mbeanName.getDomain(),
+                        jmxMBeanPropertyCache.getKeyPropertyList(mbeanName),
+                        new LinkedList<String>(),
+                        attr.getName(),
+                        attr.getType(),
+                        attr.getDescription(),
+                        attribute.getValue()
+                );
             }
-        }
-        catch (Exception e) {
-            logScrape(mbeanName.toString(), "failed to process attribute");
-            return;
         }
     }
 
@@ -288,6 +275,18 @@ class JmxScraper {
             }
         } else if (value.getClass().isArray()) {
             logScrape(domain, "arrays are unsupported");
+        } else if (value instanceof ArrayList<?>) {
+            // We can't output a list of values here, so instead let's send the count of entries
+            ArrayList<?> list = (ArrayList<?>)value;
+            logScrape(domain + beanProperties + attrName, String.valueOf(list.size()));
+            this.receiver.recordBean(
+                    domain,
+                    beanProperties,
+                    attrKeys,
+                    attrName,
+                    attrType,
+                    attrDescription,
+                    list.size());
         } else {
             logScrape(domain + beanProperties, attrType + " is not exported");
         }

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -157,21 +157,27 @@ class JmxScraper {
             logScrape(mbeanName, name2AttrInfo.keySet(), "Fail: " + e);
             return;
         }
-        for (Object attributeObj : attributes.asList()) {
-            if (Attribute.class.isInstance(attributeObj)) {
-                Attribute attribute = (Attribute)(attributeObj);
-                MBeanAttributeInfo attr = name2AttrInfo.get(attribute.getName());
-                logScrape(mbeanName, attr, "process");
-                processBeanValue(
-                        mbeanName.getDomain(),
-                        jmxMBeanPropertyCache.getKeyPropertyList(mbeanName),
-                        new LinkedList<String>(),
-                        attr.getName(),
-                        attr.getType(),
-                        attr.getDescription(),
-                        attribute.getValue()
-                );
+        try {
+            for (Object attributeObj : attributes.asList()) {
+                if (Attribute.class.isInstance(attributeObj)) {
+                    Attribute attribute = (Attribute)(attributeObj);
+                    MBeanAttributeInfo attr = name2AttrInfo.get(attribute.getName());
+                    logScrape(mbeanName, attr, "process");
+                    processBeanValue(
+                            mbeanName.getDomain(),
+                            jmxMBeanPropertyCache.getKeyPropertyList(mbeanName),
+                            new LinkedList<String>(),
+                            attr.getName(),
+                            attr.getType(),
+                            attr.getDescription(),
+                            attribute.getValue()
+                    );
+                }
             }
+        }
+        catch (Exception e) {
+            logScrape(mbeanName.toString(), "failed to process attribute");
+            return;
         }
     }
 


### PR DESCRIPTION
Based on the discussion in other pull requests, I'm creating this "for debate" rather than with the expectation that will be merged in its current state!

Basically, Apache Ignite (and others as far as I can tell) export certain JMX metrics as an ArrayList. It's not possible to directly bring this into Prometheus but returning the number of entries works reasonably well in this case. Are there better alternatives?