### PR TITLE
Update snakeyaml version to fix CVE-2017-18640

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.23</version>
+      <version>1.26</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Update snakeyaml version to 1.26 to remediate the [CVE-2017-18640](https://nvd.nist.gov/vuln/detail/CVE-2017-18640) vulnerability.