### PR TITLE
Add support for java.util.Optional MBean properties

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -54,6 +54,7 @@ class JmxScraper {
     private final boolean ssl;
     private final List<ObjectName> whitelistObjectNames, blacklistObjectNames;
     private final JmxMBeanPropertyCache jmxMBeanPropertyCache;
+    private final OptionalValueExtractor optionalValueExtractor = new OptionalValueExtractor();
 
     public JmxScraper(String jmxUrl, String username, String password, boolean ssl,
                       List<ObjectName> whitelistObjectNames, List<ObjectName> blacklistObjectNames,
@@ -282,6 +283,16 @@ class JmxScraper {
             }
         } else if (value.getClass().isArray()) {
             logScrape(domain, "arrays are unsupported");
+        } else if (optionalValueExtractor.isOptional(value)) {
+            logScrape(domain + beanProperties + attrName, "java.util.Optional");
+            processBeanValue(
+                    domain,
+                    beanProperties,
+                    attrKeys,
+                    attrName,
+                    attrType,
+                    attrDescription,
+                    optionalValueExtractor.getOptionalValueOrNull(value));
         } else {
             logScrape(domain + beanProperties, attrType + " is not exported");
         }

--- a/collector/src/main/java/io/prometheus/jmx/OptionalValueExtractor.java
+++ b/collector/src/main/java/io/prometheus/jmx/OptionalValueExtractor.java
@@ -1,0 +1,58 @@
+package io.prometheus.jmx;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class OptionalValueExtractor {
+
+    private static final Logger LOGGER = Logger.getLogger(OptionalValueExtractor.class.getName());
+
+    private static final String OPTIONAL_CLASS_NAME = "java.util.Optional";
+    private static final Class<?> OPTIONAL_CLASS = findOptionalClass();
+    private static final Method OR_ELSE_METHOD = findOrElseMethod();
+
+    private static Class<?> findOptionalClass() {
+        Class<?> optionalClass = null;
+        try {
+            optionalClass = Class.forName(OPTIONAL_CLASS_NAME);
+        } catch (ClassNotFoundException e) {
+            LOGGER.log(Level.FINE, "{0}: class not found (not running on Java 8+)", OPTIONAL_CLASS_NAME); // that's okay
+        }
+        if (optionalClass != null) {
+            LOGGER.log(Level.FINE, "{0} will be supported", OPTIONAL_CLASS_NAME);
+        }
+        return optionalClass;
+    }
+
+    private static Method findOrElseMethod() {
+        if (OPTIONAL_CLASS != null) {
+            try {
+                return OPTIONAL_CLASS.getMethod("orElse", Object.class);
+            } catch (NoSuchMethodException e) {
+                LOGGER.log(Level.WARNING, "{0}.orElse(Object): method not found!", OPTIONAL_CLASS_NAME); // that would be weird!
+            }
+        }
+        return null;
+    }
+
+    public boolean isOptional(Object o) {
+        return (o != null)
+                && OPTIONAL_CLASS == o.getClass() // Optional is final, no need for isAssignableFrom()
+                && OR_ELSE_METHOD != null; // would we be able to extract value from this Optional?
+    }
+
+    public Object getOptionalValueOrNull(Object o) {
+        try {
+            return OR_ELSE_METHOD.invoke(o, (Object) null);
+        } catch (IllegalAccessException e) {
+            LOGGER.log(Level.FINE, "IllegalAccessException calling orElse(null) on {0}", o);
+        } catch (IllegalArgumentException e) {
+            LOGGER.log(Level.FINE, "IllegalArgumentException calling orElse(null) on {0}", o);
+        } catch (InvocationTargetException e) {
+            LOGGER.log(Level.FINE, "InvocationTargetException calling orElse(null) on {0}", o);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
The SonarQube maintainers had this weird idea of an `Optional<Long>` property in an mbean:
https://github.com/SonarSource/sonarqube/blob/8.7.0.41497/server/sonar-ce/src/main/java/org/sonar/ce/monitoring/CeTasksMBean.java#L37
(IMHO, having a regular `long` property, and returning `0` when no task is currently pending, would have been fine too, but that's how it is...)

This currently can't be scraped via the `jmx_exporter` JVM agent. So here we go, a modest proposal to support `java.util.Optional`, of course only when the agent runs on Java 8+. This implementation uses Java reflection to find the `java.util.Optional` class and its `orElse(Object)` method. If found, then when an mbean property `value` is indeed an `Optional`, it will be processed as `value.orElse(null)`.

Caveats:
- don't feed it a self-referencing `Optional`, I've put no safeguard against infinite recursion on `JmxScraper.processBeanValue(...)` calls :-)
- there is no unit test. I've checked that this code works as expected on the SonarQube CE process, but I can't figure how to write a test in a Java 1.6 project. One option could be to add a Java 8 Maven submodule just to hold this test (via a profile activated only when building with Java 8+, or something like that), but honestly, that would be ugly.

Ping: @fstab and @tomwilkie