### PR TITLE
Leverages the interpolated help when the matching rule is cached (fixes #612)

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -523,7 +523,7 @@ public class JmxCollector extends Collector implements Collector.Describable {
 
         // Add to samples.
         LOGGER.fine("add metric sample: " + matchedRule.name + " " + matchedRule.labelNames + " " + matchedRule.labelValues + " " + value.doubleValue());
-        addSample(new MetricFamilySamples.Sample(matchedRule.name, matchedRule.labelNames, matchedRule.labelValues, value.doubleValue()), matchedRule.type, help);
+        addSample(new MetricFamilySamples.Sample(matchedRule.name, matchedRule.labelNames, matchedRule.labelValues, value.doubleValue()), matchedRule.type, matchedRule.help);
       }
 
     }


### PR DESCRIPTION
Fix allowing to retain the configured 'help' content when rule is cached (fixes #612).
@fstab , @tomwilkie , feel free to elaborate on this one - let me know if there is any change needed in this pull request.