### PR TITLE
Align kafka connect metrics

### DIFF
--- a/example_configs/kafka-connect.yml
+++ b/example_configs/kafka-connect.yml
@@ -61,9 +61,19 @@ rules:
     help: "Kafka $1 JMX metric type $2"
     type: GAUGE
 
+  #kafka.connect:type=connector-metrics,connector="{connector}"
+  - pattern: 'kafka.(.+)<type=connector-metrics, connector=(.+)><>(connector-class|connector-type|connector-version|status): (.+)'
+    name: kafka_connect_connector_$3
+    value: 1
+    labels:
+      connector: "$2"
+      $3: "$4"
+    help: "Kafka Connect $3 JMX metric type connector"
+    type: GAUGE
+    
   #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}<> status"
   - pattern: 'kafka.connect<type=connector-task-metrics, connector=(.+), task=(.+)><>status: ([a-z-]+)'
-    name: kafka_connect_connector_status
+    name: kafka_connect_connector_task_status
     value: 1
     labels:
       connector: "$1"


### PR DESCRIPTION
Currently, the Kafka connect task status is exposed under kafka_connect_connector_status which is not the connector status, and if the connector failed to start nothing gets exposed, I have added the Kafka connect connector metrics and renamed the existing status to kafka_connect_connector_task_status, more details are provided here:
#633
Signed-off-by: alexivsn <alex@securenative.com>