### PR TITLE
Use artifactId to generate debian package name

### DIFF
--- a/jmx_prometheus_httpserver/src/deb/control/control
+++ b/jmx_prometheus_httpserver/src/deb/control/control
@@ -1,4 +1,4 @@
-Package: [[name]]
+Package: [[artifactId]]
 Version: [[version]]
 Section: misc
 Priority: optional


### PR DESCRIPTION
- Since 77a5b8fe17520a097429cf5f47021990c0eb6438, "name" is "Prometheus
  JMX Exporter - Http Server", which break debian package generation
- use artifactId to get a correct name