### PR TITLE
Cassandra: disable two particularly slow metrics

### DIFF
--- a/example_configs/cassandra.yml
+++ b/example_configs/cassandra.yml
@@ -1,8 +1,14 @@
 lowercaseOutputLabelNames: true
 lowercaseOutputName: true
 whitelistObjectNames: ["org.apache.cassandra.metrics:*"]
-# ColumnFamily is an alias for Table metrics
-blacklistObjectNames: ["org.apache.cassandra.metrics:type=ColumnFamily,*"]
+
+blacklistObjectNames:
+  # ColumnFamily is an alias for Table metrics
+  - "org.apache.cassandra.metrics:type=ColumnFamily,*"
+  # TotalDiskSpaceUsed and EstimatedPartitionCount slow down scraping significantly
+  - "org.apache.cassandra.metrics:*,name=TotalDiskSpaceUsed"
+  - "org.apache.cassandra.metrics:*,name=EstimatedPartitionCount"
+  
 rules:
 # Generic gauges with 0-2 labels
 - pattern: org.apache.cassandra.metrics<type=(\S*)(?:, ((?!scope)\S*)=(\S*))?(?:, scope=(\S*))?, name=(\S*)><>Value


### PR DESCRIPTION
Disabling these two metrics speeds up the scrape time dramatically on our Cassandra cluster - from around 20 seconds to 2-3 seconds.

I think it's worth disabling these by default because it makes the JMX exporter much more usable with Cassandra and this trick isn't particularly obvious.