### PR TITLE
Update to client_java 0.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <prometheus.simpleclient.version>0.11.0</prometheus.simpleclient.version>
+    <prometheus.simpleclient.version>0.13.0</prometheus.simpleclient.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
I'm facing this issue: [WARNING: sendResponseHeaders: being invoked with a content length for a HEAD request #685](https://github.com/prometheus/client_java/issues/685)
client_java 0.13.0 including this fix