### PR TITLE
rd/bs - Custom JMX Exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ lowercaseOutputName | Lowercase the output metric name. Applies to default forma
 lowercaseOutputLabelNames | Lowercase the output metric label names. Applies to default format and `labels`. Defaults to false.
 whitelistObjectNames | A list of [ObjectNames](http://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html) to query. Defaults to all mBeans.
 blacklistObjectNames | A list of [ObjectNames](http://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html) to not query. Takes precedence over `whitelistObjectNames`. Defaults to none.
+blackListBeanAttributeNames | A list of bean attribute names to not query.
 rules      | A list of rules to apply in order, processing stops at the first matching rule. Attributes that aren't matched aren't collected. If not specified, defaults to collecting everything in the default format.
 pattern           | Regex pattern to match against each bean attribute. The pattern is not anchored. Capture groups can be used in other options. Defaults to matching everything.
 attrNameSnakeCase | Converts the attribute name to snake case. This is seen in the names matched by the pattern and the default format. For example, anAttrName to an\_attr\_name. Defaults to false.

--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -69,6 +69,7 @@ public class JmxCollector extends Collector implements Collector.Describable {
       boolean lowercaseOutputLabelNames;
       List<ObjectName> whitelistObjectNames = new ArrayList<ObjectName>();
       List<ObjectName> blacklistObjectNames = new ArrayList<ObjectName>();
+      List<String> blacklistBeanAttributeNames = new ArrayList<String>();
       List<Rule> rules = new ArrayList<Rule>();
       long lastUpdate = 0L;
 
@@ -204,6 +205,13 @@ public class JmxCollector extends Collector implements Collector.Describable {
           List<Object> names = (List<Object>) yamlConfig.get("blacklistObjectNames");
           for (Object name : names) {
             cfg.blacklistObjectNames.add(new ObjectName((String)name));
+          }
+        }
+
+        if (yamlConfig.containsKey("blacklistBeanAttributeNames")) {
+          List<String> names = (List<String>) yamlConfig.get("blacklistBeanAttributeNames");
+          for (String name : names) {
+            cfg.blacklistBeanAttributeNames.add(name);
           }
         }
 
@@ -563,7 +571,8 @@ public class JmxCollector extends Collector implements Collector.Describable {
       MatchedRulesCache.StalenessTracker stalenessTracker = new MatchedRulesCache.StalenessTracker();
       Receiver receiver = new Receiver(config, stalenessTracker);
       JmxScraper scraper = new JmxScraper(config.jmxUrl, config.username, config.password, config.ssl,
-              config.whitelistObjectNames, config.blacklistObjectNames, receiver, jmxMBeanPropertyCache);
+              config.whitelistObjectNames, config.blacklistObjectNames, config.blacklistBeanAttributeNames, 
+              receiver, jmxMBeanPropertyCache);
       long start = System.nanoTime();
       double error = 0;
       if ((config.startDelaySeconds > 0) &&


### PR DESCRIPTION
* Added the functionality of excluding pre-defined bean attributes from the scraping process. For our use case, this includes: CapturedTables, MonitoredTables, and RowsScanned. This is because the scrape time for these attributes takes a very long time due to the number of tables being extracted (100k-600k+). The 'blacklistObjectNames' and 'whitelistObjectNames' configurations allowed us to exclude beans, but not specific bean attributes. Hence, we introduced a new configuration parameter called 'blacklistBeanAttributeNames' which takes a list of bean attribute names to exclude. This array is then used to exclude certain attributes from being scraped.