### PR TITLE
#609 avoids some duplicated metrics

### DIFF
--- a/example_configs/kafka-connect.yml
+++ b/example_configs/kafka-connect.yml
@@ -21,7 +21,7 @@ rules:
 
   #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
   #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+), partition=(.+)><>(.+-total|compression-rate|.+-avg|.+-replica|.+-lag|.+-lead)
+  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+), partition=(.+)><>(.+-total|compression-rate|.+-avg|.+-min|.+-max|.+-replica|.+-lag|.+-lead)
     name: kafka_$2_$6
     labels:
       clientId: "$3"
@@ -76,7 +76,7 @@ rules:
   #kafka.connect:type=source-task-metrics,connector="{connector}",task="{task}"
   #kafka.connect:type=sink-task-metrics,connector="{connector}",task="{task}"
   #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}"
-  - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-ms|.+-ratio|.+-avg|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)
+  - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-ms|.+-ratio|.+-avg|.+-min|.+-max|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)
     name: kafka_connect_$1_$4
     labels:
       connector: "$2"


### PR DESCRIPTION
See issue #609.
Including `records-lag-avg` and `records-lag-max` explicitly avoids `kafka_connect_consumer_fetch_records_lag` mixing its values as seen here:
```
kafka_connect_consumer_fetch_records_lag{clientId="foo",partition="0",topic="bar",} 0.0
kafka_connect_consumer_fetch_records_lag{clientId="foo",partition="0",topic="bar",} NaN
kafka_connect_consumer_fetch_records_lag{clientId="foo",partition="0",topic="bar",} NaN
```
After applying this change:
```
# HELP kafka_connect_consumer_fetch_records_lag Kafka Connect JMX metric type consumer-fetch-manager
# TYPE kafka_connect_consumer_fetch_records_lag gauge
kafka_connect_consumer_fetch_records_lag{clientId="foo",partition="0",topic="bar",} 0.0
# HELP kafka_connect_consumer_fetch_records_lag_avg Kafka Connect JMX metric type consumer-fetch-manager
# TYPE kafka_connect_consumer_fetch_records_lag_avg gauge
kafka_connect_consumer_fetch_records_lag_avg{clientId="foo",partition="0",topic="bar",} NaN
# HELP kafka_connect_consumer_fetch_records_lag_max Kafka Connect JMX metric type consumer-fetch-manager
# TYPE kafka_connect_consumer_fetch_records_lag_max gauge
kafka_connect_consumer_fetch_records_lag_max{clientId="foo",partition="0",topic="bar",} NaN
```