### PR TITLE
Expose service port as a system property, mainly to support use-case where configured port is zero and picked by OS

### DIFF
--- a/jmx_prometheus_javaagent_java6/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent_java6/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -29,6 +29,14 @@ public class JavaAgent {
             new JmxCollector(new File(config.file), JmxCollector.Mode.AGENT).register();
             DefaultExports.initialize();
             server = new HTTPServer(config.socket, CollectorRegistry.defaultRegistry, true);
+            
+            // in case port was configured with port 0, then actual port (chosen by operating system) is known only after the socket is open
+            // in this case, we need a way to expose the actual port number used
+            // setting it as a system properties allows any other code running on the JVM to discover this
+            // this information could then be pushed into a discovery service
+            int actualServerPort = server.getPort();
+            System.setProperty("jmx_exporter.server.port.configured", String.valueOf(config.port));
+            System.setProperty("jmx_exporter.server.port.actual", String.valueOf(actualServerPort));
         }
         catch (IllegalArgumentException e) {
             System.err.println("Usage: -javaagent:/path/to/JavaAgent.jar=[host:]<port>:<yaml configuration file> " + e.getMessage());


### PR DESCRIPTION
Expose service port as a system property, mainly to support use-case where configured port is zero and picked by OS

When adding jmx_exporter java agent, you typically provide a port number as configuration.

However, you may want to rely on the operating system to pick a port number at startup time, so that you don't need to bother with assigning a different port number for the many JVMs that may be running on the same machine.

In that case, it become very difficult to discover which port what used for this particular process. (you may need to rely on various command lines to get the port for a process, still when the process opens multiple other ports this is becoming quite impossible to do, and platform dependantt)

Exposing the actual port as a system property is an handy solution. 
In this case, it become easy to get the value of the system property, from any other code running inside the JVM.

This other (application) code could then advertise this information into any discovery service.

