### PR TITLE
Add support in JmxScraper for ssl

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -335,7 +335,7 @@ class JmxScraper {
       List<ObjectName> objectNames = new LinkedList<ObjectName>();
       objectNames.add(null);
       if (args.length >= 3){
-            new JmxScraper(args[0], args[1], args[2], false, objectNames, new LinkedList<ObjectName>(),
+            new JmxScraper(args[0], args[1], args[2], (args.length >3 && "ssl".equalsIgnoreCase(args[3])), objectNames, new LinkedList<ObjectName>(),
                     new StdoutWriter(), new JmxMBeanPropertyCache()).doScrape();
         }
       else if (args.length > 0){


### PR DESCRIPTION
Last command line argument can be the string literal "ssl" to enable ssl.

System properties `-Djavax.net.ssl.keyStore=… -Djavax.net.ssl.keyStorePassword=… -Djavax.net.ssl.trustStore=… -Djavax.net.ssl.trustStorePassword=…` still need to be manually set.