### PR TITLE
Reduce cardinality of default help strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ name              | The metric name to set. Capture groups from the `pattern` ca
 value             | Value for the metric. Static values and capture groups from the `pattern` can be used. If not specified the scraped mBean value will be used.
 valueFactor       | Optional number that `value` (or the scraped mBean value if `value` is not specified) is multiplied by, mainly used to convert mBean values from milliseconds to seconds.
 labels            | A map of label name to label value pairs. Capture groups from `pattern` can be used in each. `name` must be set to use this. Empty names and values are ignored. If not specified and the default format is not being used, no labels are set.
-help              | Help text for the metric. Capture groups from `pattern` can be used. `name` must be set to use this. Defaults to the mBean attribute description and the full name of the attribute.
+help              | Help text for the metric. Capture groups from `pattern` can be used. `name` must be set to use this. Defaults to the mBean attribute description, domain, and name of the attribute.
 cache             | Whether to cache bean name expressions to rule computation (match and mismatch). Not recommended for rules matching on bean value, as only the value from the first scrape will be cached and re-used. This can increase performance when collecting a lot of mbeans. Defaults to `false`.
 type              | The type of the metric, can be `GAUGE`, `COUNTER` or `UNTYPED`. `name` must be set to use this. Defaults to `UNTYPED`.
 

--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -451,8 +451,14 @@ public class JmxCollector extends Collector implements Collector.Describable {
           Object beanValue) {
 
         String beanName = domain + angleBrackets(beanProperties.toString()) + angleBrackets(attrKeys.toString());
-        // attrDescription tends not to be useful, so give the fully qualified name too.
-        String help = attrDescription + " (" + beanName + attrName + ")";
+
+        // Build the HELP string from the bean metadata.
+        String help = domain + ":name=" + beanProperties.get("name") + ",type=" + beanProperties.get("type") + ",attribute=" + attrName;
+        // Add the attrDescription to the HELP if it exists and is useful.
+        if (attrDescription != null && !attrDescription.equals(attrName)) {
+          help = attrDescription + " " + help;
+        }
+
         String attrNameSnakeCase = toSnakeAndLowerCase(attrName);
 
         MatchedRule matchedRule = MatchedRule.unmatched();


### PR DESCRIPTION
Including the whole mBean fully qualified name can produce a huge amount
of HELP metadata cardinality, slowing down the UI and bloating the TSDB
indexes.

Fixes: https://github.com/prometheus/jmx_exporter/issues/703

Signed-off-by: SuperQ <superq@gmail.com>