### PR TITLE
add simple auth for httpserver

### DIFF
--- a/jmx_prometheus_javaagent_common/src/main/java/io/prometheus/jmx/SimpleAuthenticator.java
+++ b/jmx_prometheus_javaagent_common/src/main/java/io/prometheus/jmx/SimpleAuthenticator.java
@@ -1,0 +1,21 @@
+package io.prometheus.jmx;
+
+import com.sun.net.httpserver.BasicAuthenticator;
+
+public class SimpleAuthenticator extends BasicAuthenticator {
+    private String username;
+    private String password;
+
+    public SimpleAuthenticator(String realm, String username, String password) {
+        super(realm);
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public boolean checkCredentials(String username, String password) {
+        return username != null && password != null
+                && this.username != null && this.password != null
+                && username.equals(this.username) && password.equals(this.password);
+    }
+}


### PR DESCRIPTION
although there is auth support for collector, but httpserver is not use this auth, and I add a simple SimpleAuthenticator which will check auth which has been configured in yml with item name "username" and "password"

Signed-off-by: dqyang <dqyang@freewheel.tv>