### PR TITLE
Added option to scrape all types of attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ username   | The username to be used in remote JMX password authentication.
 password   | The password to be used in remote JMX password authentication.
 jmxUrl     | A full JMX URL to connect to. Should not be specified if hostPort is.
 ssl        | Whether JMX connection should be done over SSL. To configure certificates you have to set following system properties:<br/>`-Djavax.net.ssl.keyStore=/home/user/.keystore`<br/>`-Djavax.net.ssl.keyStorePassword=changeit`<br/>`-Djavax.net.ssl.trustStore=/home/user/.truststore`<br/>`-Djavax.net.ssl.trustStorePassword=changeit`
+scrapeAllAttributes | Option to scrape everything from JMX, otherwise only Attribute instances will be scraped, default: false
 lowercaseOutputName | Lowercase the output metric name. Applies to default format and `name`. Defaults to false.
 lowercaseOutputLabelNames | Lowercase the output metric label names. Applies to default format and `labels`. Defaults to false.
 whitelistObjectNames | A list of [ObjectNames](http://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html) to query. Defaults to all mBeans.

--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -65,6 +65,7 @@ public class JmxCollector extends Collector implements Collector.Describable {
       String username = "";
       String password = "";
       boolean ssl = false;
+      boolean scrapeAllAttributes = false;
       boolean lowercaseOutputName;
       boolean lowercaseOutputLabelNames;
       List<ObjectName> whitelistObjectNames = new ArrayList<ObjectName>();
@@ -181,6 +182,10 @@ public class JmxCollector extends Collector implements Collector.Describable {
 
         if (yamlConfig.containsKey("ssl")) {
           cfg.ssl = (Boolean)yamlConfig.get("ssl");
+        }
+
+        if (yamlConfig.containsKey("scrapeAllAttributes")) {
+          cfg.scrapeAllAttributes = (Boolean)yamlConfig.get("scrapeAllAttributes");
         }
 
         if (yamlConfig.containsKey("lowercaseOutputName")) {
@@ -587,7 +592,7 @@ public class JmxCollector extends Collector implements Collector.Describable {
 
       MatchedRulesCache.StalenessTracker stalenessTracker = new MatchedRulesCache.StalenessTracker();
       Receiver receiver = new Receiver(config, stalenessTracker);
-      JmxScraper scraper = new JmxScraper(config.jmxUrl, config.username, config.password, config.ssl,
+      JmxScraper scraper = new JmxScraper(config.jmxUrl, config.username, config.password, config.ssl, config.scrapeAllAttributes
               config.whitelistObjectNames, config.blacklistObjectNames, receiver, jmxMBeanPropertyCache);
       long start = System.nanoTime();
       double error = 0;


### PR DESCRIPTION
Hi @fstab, @tomwilkie 

The reason I have created this PR is while scraping JMX metrics from apache ignite, if I used JMXMetricsSpi, exporter was not able to parse any of the metrics provided by specific SPI. The Attributes are returned as POJOs instead of the expectation Attribute implementation.

I have added an option to scrape everything from JMX, current implementation scrapes Attribute instances only.
Config key: `scrapeAllAttributes` 

Signed-off-by: Umut Sahin <umutshin@gmail.com>