### PR TITLE
Fixed packaging to add version and name to build info metric

### DIFF
--- a/jmx_prometheus_httpserver/pom.xml
+++ b/jmx_prometheus_httpserver/pom.xml
@@ -52,6 +52,8 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>io.prometheus.jmx.WebServer</Main-Class>
+                                        <Implementation-Version>${project.version}</Implementation-Version>
+                                        <Implementation-Title>${project.artifactId}</Implementation-Title>
                                     </manifestEntries>
                                 </transformer>
                             </transformers>

--- a/jmx_prometheus_httpserver_java6/pom.xml
+++ b/jmx_prometheus_httpserver_java6/pom.xml
@@ -63,6 +63,8 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>io.prometheus.jmx.WebServer</Main-Class>
+                                        <Implementation-Version>${project.version}</Implementation-Version>
+                                        <Implementation-Title>${project.artifactId}</Implementation-Title>
                                     </manifestEntries>
                                 </transformer>
                             </transformers>


### PR DESCRIPTION
Fixed packaging to add version and name to build info metric for the HTTP server. (The Agent builds work correctly.)
Added integration tests to validate that the name is correct and that the version is not "unknown" for all builds.

https://github.com/prometheus/jmx_exporter/issues/728