### PR TITLE
fix(examples): add missing kafka quota pattern

### DIFF
--- a/example_configs/kafka-2_0_0.yml
+++ b/example_configs/kafka-2_0_0.yml
@@ -36,20 +36,6 @@ rules:
   type: COUNTER
 
 # Quota specific rules
-- pattern: kafka.server<type=(.+), client-id=(.+)><>([a-z-]+)
-  name: kafka_server_quota_$3
-  type: GAUGE
-  labels:
-    resource: "$1"
-    clientId: "$2"
-    
-- pattern: kafka.server<type=(.+), user=(.+)><>([a-z-]+)
-  name: kafka_server_quota_$3
-  type: GAUGE
-  labels:
-    resource: "$1"
-    user: "$2"
-
 - pattern: kafka.server<type=(.+), user=(.+), client-id=(.+)><>([a-z-]+)
   name: kafka_server_quota_$4
   type: GAUGE
@@ -57,6 +43,18 @@ rules:
     resource: "$1"
     user: "$2"
     clientId: "$3"
+- pattern: kafka.server<type=(.+), client-id=(.+)><>([a-z-]+)
+  name: kafka_server_quota_$3
+  type: GAUGE
+  labels:
+    resource: "$1"
+    clientId: "$2"
+- pattern: kafka.server<type=(.+), user=(.+)><>([a-z-]+)
+  name: kafka_server_quota_$3
+  type: GAUGE
+  labels:
+    resource: "$1"
+    user: "$2"
 
 # Generic gauges with 0-2 key/value pairs
 - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Value

--- a/example_configs/kafka-2_0_0.yml
+++ b/example_configs/kafka-2_0_0.yml
@@ -35,12 +35,20 @@ rules:
   name: kafka_$1_$2_$3_total
   type: COUNTER
 
+# Quota specific rules
 - pattern: kafka.server<type=(.+), client-id=(.+)><>([a-z-]+)
   name: kafka_server_quota_$3
   type: GAUGE
   labels:
     resource: "$1"
     clientId: "$2"
+    
+- pattern: kafka.server<type=(.+), user=(.+)><>([a-z-]+)
+  name: kafka_server_quota_$3
+  type: GAUGE
+  labels:
+    resource: "$1"
+    user: "$2"
 
 - pattern: kafka.server<type=(.+), user=(.+), client-id=(.+)><>([a-z-]+)
   name: kafka_server_quota_$4


### PR DESCRIPTION
Quotas can be specified in tupples (user, client-id). The user and client-id can also be used isolated.

So added the missing rule.

@fstab
@tomwilkie