### PR TITLE
Bump up source and target from 1.6 to 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,8 +237,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
1.6 is no longer supported by maven plugin.
Build and tests run successfully.