### PR TITLE
Fix for CVE-2022-1471

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.33</version> <!-- The Java 6 build overrides this with 1.23. -->
+            <version>2.0</version> <!-- The Java 6 build overrides this with 1.23. -->
         </dependency>
     </dependencies>
 

--- a/collector/src/main/java/io/prometheus/jmx/FilteringSafeConstructor.java
+++ b/collector/src/main/java/io/prometheus/jmx/FilteringSafeConstructor.java
@@ -1,0 +1,19 @@
+package io.prometheus.jmx;
+
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+/**
+ * Class to implement an extension to SafeConstructor to handle SnakeYAML version differences
+ *
+ * This is a SnakeYAML version 2.0.0 which provides safe filtering
+ *
+ * Java 6 versions of this class implement safe filtering of entity types
+ */
+public class FilteringSafeConstructor extends SafeConstructor {
+
+    public FilteringSafeConstructor() {
+        super(new LoaderOptions());
+    }
+}
+

--- a/collector/src/main/java/io/prometheus/jmx/FilteringSafeConstructor.java
+++ b/collector/src/main/java/io/prometheus/jmx/FilteringSafeConstructor.java
@@ -6,7 +6,7 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 /**
  * Class to implement an extension to SafeConstructor to handle SnakeYAML version differences
  *
- * This is a SnakeYAML version 2.0.0 which provides safe filtering
+ * This is a SnakeYAML 2.0.0 version implementation which provides safe filtering
  *
  * Java 6 versions of this class implement safe filtering of entity types
  */

--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -88,18 +88,18 @@ public class JmxCollector extends Collector implements Collector.Describable {
     public JmxCollector(File in, Mode mode) throws IOException, MalformedObjectNameException {
         configFile = in;
         this.mode = mode;
-        config = loadConfig((Map<String, Object>)new Yaml().load(new FileReader(in)));
+        config = loadConfig((Map<String, Object>)new Yaml(new FilteringSafeConstructor()).load(new FileReader(in)));
         config.lastUpdate = configFile.lastModified();
         exitOnConfigError();
     }
 
     public JmxCollector(String yamlConfig) throws MalformedObjectNameException {
-        config = loadConfig((Map<String, Object>)new Yaml().load(yamlConfig));
+        config = loadConfig((Map<String, Object>)new Yaml(new FilteringSafeConstructor()).load(yamlConfig));
         mode = null;
     }
 
     public JmxCollector(InputStream inputStream) throws MalformedObjectNameException {
-        config = loadConfig((Map<String, Object>)new Yaml().load(inputStream));
+        config = loadConfig((Map<String, Object>)new Yaml(new FilteringSafeConstructor()).load(inputStream));
         mode = null;
     }
 
@@ -119,7 +119,7 @@ public class JmxCollector extends Collector implements Collector.Describable {
         FileReader fr = new FileReader(configFile);
 
         try {
-          Map<String, Object> newYamlConfig = (Map<String, Object>)new Yaml().load(fr);
+          Map<String, Object> newYamlConfig = (Map<String, Object>)new Yaml(new FilteringSafeConstructor()).load(fr);
           config = loadConfig(newYamlConfig);
           config.lastUpdate = configFile.lastModified();
           configReloadSuccess.inc();

--- a/jmx_prometheus_httpserver_java6/src/main/java/io/prometheus/jmx/FilteringSafeConstructor.java
+++ b/jmx_prometheus_httpserver_java6/src/main/java/io/prometheus/jmx/FilteringSafeConstructor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-2023 Douglas Hoard
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prometheus.jmx;
+
+import org.yaml.snakeyaml.constructor.Constructor;
+
+import java.math.BigInteger;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class FilteringSafeConstructor extends Constructor {
+
+    private Set<String> allowedClassNameSet;
+
+    public FilteringSafeConstructor() {
+        super();
+
+        allowedClassNameSet = new HashSet<String>();
+        allowedClassNameSet.add(null);
+        allowedClassNameSet.add(BigInteger.class.getName());
+        allowedClassNameSet.add(Boolean.class.getName());
+        allowedClassNameSet.add(Byte.class.getName());
+        allowedClassNameSet.add(Character.class.getName());
+        allowedClassNameSet.add(Date.class.getName());
+        allowedClassNameSet.add(java.sql.Date.class.getName());
+        allowedClassNameSet.add(Double.class.getName());
+        allowedClassNameSet.add(Float.class.getName());
+        allowedClassNameSet.add(Integer.class.getName());
+        allowedClassNameSet.add(List.class.getName());
+        allowedClassNameSet.add(Long.class.getName());
+        allowedClassNameSet.add(Map.class.getName());
+        allowedClassNameSet.add(Set.class.getName());
+        allowedClassNameSet.add(Short.class.getName());
+        allowedClassNameSet.add(String.class.getName());
+        allowedClassNameSet.add(Timestamp.class.getName());
+    }
+
+    @Override
+    protected Class<?> getClassForName(String name) throws ClassNotFoundException {
+        if (!allowedClassNameSet.contains(name)) {
+            throw new IllegalStateException(String.format("Class [%s] isn't allowed", name));
+        }
+
+        return super.getClassForName(name);
+    }
+}

--- a/jmx_prometheus_javaagent_java6/src/main/java/io/prometheus/jmx/FilteringSafeConstructor.java
+++ b/jmx_prometheus_javaagent_java6/src/main/java/io/prometheus/jmx/FilteringSafeConstructor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-2023 Douglas Hoard
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prometheus.jmx;
+
+import org.yaml.snakeyaml.constructor.Constructor;
+
+import java.math.BigInteger;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class FilteringSafeConstructor extends Constructor {
+
+    private Set<String> allowedClassNameSet;
+
+    public FilteringSafeConstructor() {
+        super();
+
+        allowedClassNameSet = new HashSet<String>();
+        allowedClassNameSet.add(null);
+        allowedClassNameSet.add(BigInteger.class.getName());
+        allowedClassNameSet.add(Boolean.class.getName());
+        allowedClassNameSet.add(Byte.class.getName());
+        allowedClassNameSet.add(Character.class.getName());
+        allowedClassNameSet.add(Date.class.getName());
+        allowedClassNameSet.add(java.sql.Date.class.getName());
+        allowedClassNameSet.add(Double.class.getName());
+        allowedClassNameSet.add(Float.class.getName());
+        allowedClassNameSet.add(Integer.class.getName());
+        allowedClassNameSet.add(List.class.getName());
+        allowedClassNameSet.add(Long.class.getName());
+        allowedClassNameSet.add(Map.class.getName());
+        allowedClassNameSet.add(Set.class.getName());
+        allowedClassNameSet.add(Short.class.getName());
+        allowedClassNameSet.add(String.class.getName());
+        allowedClassNameSet.add(Timestamp.class.getName());
+    }
+
+    @Override
+    protected Class<?> getClassForName(String name) throws ClassNotFoundException {
+        if (!allowedClassNameSet.contains(name)) {
+            throw new IllegalStateException(String.format("Class [%s] isn't allowed", name));
+        }
+
+        return super.getClassForName(name);
+    }
+}


### PR DESCRIPTION
This is a fix for CVE-2022-1471.

Due to changes in the SnakeYAML 2.0 `Constructor` between 2.0 and 1.23 (the last version to support Java 6), I had to introduce a wrapper class `FilteringSafeConstructor` which I could then implement specifically for Java 6 artifacts.

https://github.com/prometheus/jmx_exporter/issues/776
