### PR TITLE
Adding an `excludeBeanAttributeNames` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ lowercaseOutputName: false
 lowercaseOutputLabelNames: false
 whitelistObjectNames: ["org.apache.cassandra.metrics:*"]
 blacklistObjectNames: ["org.apache.cassandra.metrics:type=ColumnFamily,*"]
+excludeBeanAttributeNames:
+  - name: "org.apache.cassandra.metrics:type=ColumnFamily,*"
+    values:
+    - BloomFilterDiskSpaceUsed
+    - BloomFilterFalsePositives
 rules:
   - pattern: 'org.apache.cassandra.metrics<type=(\w+), name=(\w+)><>Value: (\d+)'
     name: cassandra_$1_$2
@@ -107,6 +112,7 @@ lowercaseOutputName | Lowercase the output metric name. Applies to default forma
 lowercaseOutputLabelNames | Lowercase the output metric label names. Applies to default format and `labels`. Defaults to false.
 whitelistObjectNames | A list of [ObjectNames](http://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html) to query. Defaults to all mBeans.
 blacklistObjectNames | A list of [ObjectNames](http://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html) to not query. Takes precedence over `whitelistObjectNames`. Defaults to none.
+excludeBeanAttributeNames | A list of dictionaries, where each dictionary contains an [ObjectName](http://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html) and list of attributes to exclude. Defaults to none.
 rules      | A list of rules to apply in order, processing stops at the first matching rule. Attributes that aren't matched aren't collected. If not specified, defaults to collecting everything in the default format.
 pattern           | Regex pattern to match against each bean attribute. The pattern is not anchored. Capture groups can be used in other options. Defaults to matching everything.
 attrNameSnakeCase | Converts the attribute name to snake case. This is seen in the names matched by the pattern and the default format. For example, anAttrName to an\_attr\_name. Defaults to false.

--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -72,6 +72,7 @@ public class JmxCollector extends Collector implements Collector.Describable {
       List<ObjectName> whitelistObjectNames = new ArrayList<ObjectName>();
       List<ObjectName> blacklistObjectNames = new ArrayList<ObjectName>();
       List<Rule> rules = new ArrayList<Rule>();
+      Map<ObjectName, HashSet<String>> excludeBeanAttributeNames = new HashMap<ObjectName, HashSet<String>>();
       long lastUpdate = 0L;
 
       MatchedRulesCache rulesCache;
@@ -206,6 +207,13 @@ public class JmxCollector extends Collector implements Collector.Describable {
           List<Object> names = (List<Object>) yamlConfig.get("blacklistObjectNames");
           for (Object name : names) {
             cfg.blacklistObjectNames.add(new ObjectName((String)name));
+          }
+        }
+
+        if (yamlConfig.containsKey("excludeBeanAttributeNames")) {
+          List<Map<String, Object>> attributeObjects = (List<Map<String, Object>>)  yamlConfig.get("excludeBeanAttributeNames");
+          for (Map<String, Object> attributeObject : attributeObjects) {
+            cfg.excludeBeanAttributeNames.put(new ObjectName((String)attributeObject.get("name")), new HashSet((List)attributeObject.get("values")));
           }
         }
 
@@ -626,7 +634,8 @@ public class JmxCollector extends Collector implements Collector.Describable {
       MatchedRulesCache.StalenessTracker stalenessTracker = new MatchedRulesCache.StalenessTracker();
       Receiver receiver = new Receiver(config, stalenessTracker);
       JmxScraper scraper = new JmxScraper(config.jmxUrl, config.username, config.password, config.ssl,
-              config.whitelistObjectNames, config.blacklistObjectNames, receiver, jmxMBeanPropertyCache);
+              config.whitelistObjectNames, config.blacklistObjectNames, config.excludeBeanAttributeNames,
+              receiver, jmxMBeanPropertyCache);
       long start = System.nanoTime();
       double error = 0;
       if ((config.startDelaySeconds > 0) &&

--- a/collector/src/test/java/io/prometheus/jmx/DebeziumMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/DebeziumMBean.java
@@ -1,0 +1,37 @@
+package io.prometheus.jmx;
+
+import javax.management.*;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+public interface DebeziumMBean {
+    public int getTotalNumberOfEventsSeen();
+    public int getTotalNumberOfCreateEventsSeen();
+}
+
+class Debezium implements DebeziumMBean {
+
+    public static void registerBean(MBeanServer mbs)
+            throws javax.management.JMException {
+        ObjectName mbeanName1 = new ObjectName(
+                "debezium.mysql:type=connector-metrics,context=streaming,server=dbserver1");
+        ObjectName mbeanName2 = new ObjectName(
+                "debezium.mysql:type=connector-metrics,context=streaming,server=dbserver2");
+        ObjectName mbeanName3 = new ObjectName(
+                "debezium.mysql:type=connector-metrics,context=streaming,server=dbserver3");
+        Debezium mbean = new Debezium();
+        mbs.registerMBean(mbean, mbeanName1);
+        mbs.registerMBean(mbean, mbeanName2);
+        mbs.registerMBean(mbean, mbeanName3);
+    }
+
+
+    public int getTotalNumberOfEventsSeen() {
+        return 1;
+    }
+
+    public int getTotalNumberOfCreateEventsSeen() {
+        return 1;
+    }
+}
+


### PR DESCRIPTION
This change adds a configuration which allows users to specify an MBean attribute exclusion list. This is required when the `blacklistObjectNames` or `whitelistObjectNames` are not sufficient to exclude specific attributes. For our use case, we found it necessary when using the Jmx Exporter for Debezium. There are a couple of metrics which return strings for every table within a connector. Due to the volume of tables, we ran into issues where the JMX exporter would take >10 mins to return each time it was invoked. The metrics that caused this are:

- `CapturedTables` (https://debezium.io/documentation/reference/1.9/connectors/mysql.html#connectors-snaps-metric-capturedtables_mysql)
- `RowsScanned` (https://debezium.io/documentation/reference/1.9/connectors/mysql.html#connectors-snaps-metric-rowsscanned_mysql)

We introduced a new key in the configuration file called `excludeBeanAttributeNames` which is a list of maps where each map contains the bean `ObjectName` and a list of attributes to exclude:

```
excludeBeanAttributeNames:
 - name: <beanObjectName_1>
   values:
    - <METRIC_1_TO_EXCLUDE>
    - <METRIC_2_TO_EXCLUDE>
    - <METRIC_3_TO_EXCLUDE>
    ...
 - name: <beanObjectName_2>
   values:
   - <METRIC_1_TO_EXCLUDE>
   - <METRIC_2_TO_EXCLUDE>
   - <METRIC_3_TO_EXCLUDE>
   ...
```

Using the configuration above, the following steps have been added as part of this change:

1. If there is a key called `excludeBeanAttributeNames` in the yamlConfig, we create a HashMap, where the key is a bean `ObjectName` and the value is a set of attributes to exclude.
2. This HashMap is passed into the constructor for the `JmxScraper`, where we loop over each entry in the HashMap and query the MBeans for each `ObjectName`. We create a new HashMap, where the key is the MBean name, and the value is the set of attributes to exclude.
3. During the loop where we are iterating over each bean to scrape, we check to see if there is an entry in the HashMap for the MBean containing a set of attributes to exclude. If there is, it is passed into the invocation of `scrapeBean`.
4. Within the `scrapeBean` function, while looping over each attribute for a MBean, we skip over any attributes in the set of attributes to exclude.
