### PR TITLE
Refactored `BuildInfoCollector` for optimization

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/BuildInfoCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/BuildInfoCollector.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2018-2023 The Prometheus jmx_exporter Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.prometheus.jmx;
 
 import io.prometheus.client.Collector;
@@ -23,24 +39,41 @@ import static java.util.Arrays.asList;
  * </pre>
  */
 public class BuildInfoCollector extends Collector {
-  public List<Collector.MetricFamilySamples> collect() {
-    List<Collector.MetricFamilySamples> mfs = new ArrayList<Collector.MetricFamilySamples>();
 
-    GaugeMetricFamily artifactInfo = new GaugeMetricFamily(
-            "jmx_exporter_build_info",
-            "A metric with a constant '1' value labeled with the version of the JMX exporter.",
-            asList("version", "name"));
+    private final List<Collector.MetricFamilySamples> metricFamilySamples;
 
-    Package pkg = this.getClass().getPackage();
-    String version = pkg.getImplementationVersion();
-    String name = pkg.getImplementationTitle();
+    /**
+     * Constructor
+     */
+    public BuildInfoCollector() {
+        super();
 
-    artifactInfo.addMetric(asList(
-            version != null ? version : "unknown",
-            name != null ? name : "unknown"
-    ), 1L);
-    mfs.add(artifactInfo);
+        metricFamilySamples = new ArrayList<Collector.MetricFamilySamples>();
 
-    return mfs;
-  }
+        GaugeMetricFamily artifactInfo =
+                new GaugeMetricFamily(
+                    "jmx_exporter_build_info",
+                    "A metric with a constant '1' value labeled with the version of the JMX exporter.",
+                    asList("version", "name"));
+
+        Package pkg = this.getClass().getPackage();
+        String version = pkg.getImplementationVersion();
+        String name = pkg.getImplementationTitle();
+
+        artifactInfo.addMetric(
+                asList(version != null ? version : "unknown", name != null ? name : "unknown"),
+                1L);
+
+        metricFamilySamples.add(artifactInfo);
+    }
+
+    /**
+     * Method to get the List of MetricFamilySamples
+     *
+     * @return the return value
+     */
+    @Override
+    public List<Collector.MetricFamilySamples> collect() {
+        return metricFamilySamples;
+    }
 }


### PR DESCRIPTION
Refactored `BuildInfoCollector` for optimization. The build information is static for a jar, so rebuilding it on every collection isn't required.