### PR TITLE
Agent for Apache Spark on EMR

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ rules:
 
 As stated above, it is recommended to run JMX exporter as a Java agent and not as a standalone HTTP server.
 
-## Building
-
 `./mvnw clean package` to build.
 
 ## Configuration
@@ -150,6 +148,58 @@ The default format will transform beans in a way that should produce sane metric
 domain_beanPropertyValue1_key1_key2_...keyN_attrName{beanpropertyName2="beanPropertyValue2", ...}: value
 ```
 If a given part isn't set, it'll be excluded.
+
+## Running the MultiPort Java Agent
+
+The reason for creation of this agent is monitoring and providing multiple webserver running on 1 machine. Origin of it
+stems from running Apache Spark jobs on EMR clusters, where it's typical to have more than 1 executor running on 1 machine.
+
+Differences compared to **Java Agent**
+* different configuration string format
+* it is capable of running more than 1 webserver on 1 machine
+
+### Apache Spark example configuration
+
+```bash
+# version of the agent
+AGENT_VERSION="0.17.2"
+
+# path to javagent_multiport jar on S3
+JMX_JAVA_AGENT_JAR_S3_PATH="s3://bucket/jmx_prometheus_javaagent_multiport-${AGENT_VERSION}.jar"
+
+# path to configuration file for the agent on S3 
+JMX_JAVA_AGENT_CONFIG_S3_PATH="s3://bucket/jmx_exporter.yaml"
+
+spark-submit --master yarn --deploy-mode cluster \
+--jars "${JMX_JAVA_AGENT_JAR_S3_PATH}" \
+--files "${JMX_JAVA_AGENT_CONFIG_S3_PATH}" \
+--conf "spark.driver.extraJavaOptions=-javaagent:./jmx_prometheus_javaagent_multiport-${AGENT_VERSION}.jar=portStart=222,portEnd=333,configFile=./jmx_exporter.yaml" \
+--conf "spark.executor.extraJavaOptions=-javaagent:./jmx_prometheus_javaagent_multiport-${AGENT_VERSION}.jar=portStart=222,portEnd=333,configFile=./jmx_exporter.yaml" \
+```
+
+### Configuration
+
+With 6 parameters in total it has become rather impractical to extend the config line parsing with regex.
+
+The configuration string has following shape `hostname=some_host.dc,portStart=222,portEnd=333,timeout=500,backoffMin=2000,backoffMax=4000,configFile=/some/path.yaml`.
+
+| Parameter  | value                                                                         | optional | note                                                                                                                |
+|------------|-------------------------------------------------------------------------------|----------|---------------------------------------------------------------------------------------------------------------------|
+| hostname   | typically not used                                                            | true     | defaults to 0.0.0.0                                                                                                 |
+| portStart  | port number - start of the range                                              | false    |                                                                                                                     |
+| portEnd    | port number - start of the range                                              | false    | the range must be continuous                                                                                        |
+| timeout    | timeout on how long will the agent try to connect to an supposedly empty port | true     | default is 500ms                                                                                                    |
+| backoffMin | backoff before the agent will try to lookup and start on a given port         | true     | default is 2000ms                                                                                                   |
+| backoffMax | backoff before the agent will try to lookup and start on a given port         | true     | default is 4000ms                                                                                                   |                              
+| configFile | path to the config file                                                       | false    | if used with `spark-submit --files`, it will be located on the same level as the jar. For example (`./config.yaml`) |                              
+
+
+
+### Caveats
+
+* You need to know how many ports you will need. This will depend on your system
+* To play it safe, give enough headroom for your application
+## Building
 
 ## Integration Testing
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ rules:
 
 As stated above, it is recommended to run JMX exporter as a Java agent and not as a standalone HTTP server.
 
+## Building
+
 `./mvnw clean package` to build.
 
 ## Configuration
@@ -162,7 +164,7 @@ Differences compared to **Java Agent**
 
 ```bash
 # version of the agent
-AGENT_VERSION="0.17.2"
+AGENT_VERSION="0.18.1"
 
 # path to javagent_multiport jar on S3
 JMX_JAVA_AGENT_JAR_S3_PATH="s3://bucket/jmx_prometheus_javaagent_multiport-${AGENT_VERSION}.jar"
@@ -197,9 +199,8 @@ The configuration string has following shape `hostname=some_host.dc,portStart=22
 
 ### Caveats
 
-* You need to know how many ports you will need. This will depend on your system
-* To play it safe, give enough headroom for your application
-## Building
+* You need to know how many JVMs will run on each node and play it safe by giving enough headroom for your application
+* Some ports will be wasted and never used
 
 ## Integration Testing
 

--- a/jmx_prometheus_javaagent_common/src/main/java/io/prometheus/jmx/JavaAgentMultiPort.java
+++ b/jmx_prometheus_javaagent_common/src/main/java/io/prometheus/jmx/JavaAgentMultiPort.java
@@ -1,0 +1,231 @@
+package io.prometheus.jmx;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.HTTPServer;
+import io.prometheus.client.hotspot.DefaultExports;
+
+import javax.management.MalformedObjectNameException;
+import java.io.File;
+import java.io.IOException;
+import java.lang.instrument.Instrumentation;
+import java.net.ConnectException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Random;
+
+public class JavaAgentMultiPort {
+    static HTTPServer server;
+    static Random RNG = new Random();
+    static HashMap<Integer, Integer> failedAttempts = new HashMap<Integer, Integer>();
+
+    public static void agentmain(String agentArgument, Instrumentation instrumentation) throws Exception {
+        premain(agentArgument, instrumentation);
+    }
+
+    public static void premain(String agentArgument, Instrumentation instrumentation)  {
+        // Bind to all interfaces by default (this includes IPv6).
+        try {
+            Config config = parseConfig(agentArgument);
+            new BuildInfoCollector().register();
+            new JmxCollector(new File(config.configFile), JmxCollector.Mode.AGENT).register();
+            DefaultExports.initialize();
+            startMultipleServers(config, config.portEnd - config.portStart + 1, config.backoffMin, config.backoffMax);
+        } catch (Exception e) {
+            System.err.println("Example Usage: -javaagent:/path/to/JavaAgent.jar=hostname=some_host.dc,portStart=222,portEnd=333,[timeout=500],[backoffMin=2000],[backoffMax=4000],configFile=/some/path.yaml \n" + e.getMessage());
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Checks if a connection can be made to host:port. If A connection is successful, it means there is already an agent
+     * running on that host:port. In this case we will look to the next port (port + 1) and repeat, until we run out of
+     * ports defined a range or fail to make a connection. Failure to make connection means there is no agent running yet,
+     * on that host:port
+     *
+     * @param host Host we are checking (typically 0.0.0.0)
+     * @param timeout Timeout on connection attempt
+     * @param port Port we are checking (automatically incremented)
+     * @param portLookupAttempts Limits how many look-ups we will make on this host
+     * @return A connection on which will an agent start
+     * @throws ConnectException
+     */
+    public static InetSocketAddress findAvailableSocket(final String host, final int timeout, int port, int portLookupAttempts) throws ConnectException {
+        System.out.println("Looking up free port. Checking: " + port + ", remaining ports in range: " + portLookupAttempts);
+        if (portLookupAttempts == 0) {
+            System.err.println("Run out of ports to try. Agent won't start.");
+            return null;
+        }
+        try {
+            if (failedAttempts.containsKey(port) && failedAttempts.get(port) >= 3) {
+                /* On some occasions, the agent/webserver tried to start on one particular port and despite the port
+                 * being free, it kept failing. This will make it step over the port.
+                 */
+                System.out.println("Skipping " + port + ", because off too many retries on it");
+                port += 1;
+                portLookupAttempts -= 1;
+            }
+            Socket socket = new Socket();
+            final InetAddress inetAddress = InetAddress.getByName(host);
+            final InetSocketAddress inetSocketAddress = new InetSocketAddress(inetAddress, port);
+            // if it will make the connection, it means something else is running on that port already
+            socket.connect(inetSocketAddress, timeout);
+            System.out.println("Port " + port + " is used. Trying next one.");
+            socket.close();
+            return findAvailableSocket(host, timeout, port + 1, portLookupAttempts - 1);
+        } catch (IOException e) {
+            // when it fails to make connection the socket, it is considered as free.
+            System.out.println("Found free port " + port);
+            return JavaAgentMultiPort.createInetSocket(host, port);
+        }
+    }
+
+    /**
+     * Starts number of agents/servers that provides metrics
+     *
+     * @param config  config
+     * @param retries indicating how many times the agent will attempt to launch after a 'port collision' with another
+     *                agent. Value is set to the same number as ports in the range.
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public static void startMultipleServers(Config config, int retries, int minBackoff, int maxBackoff) throws IOException, InterruptedException {
+        int portLookupAttemnpts = config.portEnd - config.portStart + 1;
+        // Randomize start to prevent race conditions on startup
+        if (portLookupAttemnpts > 1) {
+            backoff(minBackoff, maxBackoff, "server start");
+        }
+        /*
+         * Retries indicate how many times the agent will try to start (including port search). Sometimes a port is
+         * deemed free, but more than 1 agent has picked that particular port and only 1 will get it. The ones who
+         * lose out, will be given the #<retries> to start again.
+         *
+         * portLookupAttempts is "just" for scanning the range of ports.
+         */
+        InetSocketAddress socketUpdate = findAvailableSocket(config.host, config.timeout, config.portStart, portLookupAttemnpts);
+        config.setSocket(socketUpdate); //this does not update config.port
+        if (config.socket != null) {
+            try {
+                System.out.println("Trying to start JMX agent on " + config.socket.getPort());
+                server = new HTTPServer(config.socket, CollectorRegistry.defaultRegistry, true);
+                System.out.println("Started JMX on " + config.socket.getPort() + ". (retries left: " + retries + ")");
+            } catch (IOException e) {
+                if (retries <= 0) {
+                    System.out.println("Ran out of retries.");
+                    throw e;
+                }
+                System.out.println("Port has been taken before server started - retrying to start." + "(retries left: " + retries + ")");
+                /*
+                 * This had to be introduced, because of competition for resources. There is 'n' number of executors/agents
+                 * which will compete for first port in range. It can happen that port is determined to be free, but
+                 * before server start, it will be taken by a different agent. Each agent acts independently.
+                 */
+                if (failedAttempts.containsKey(config.socket.getPort())) {
+                    failedAttempts.put(config.socket.getPort(), failedAttempts.get(config.socket.getPort()) + 1);
+                } else {
+                    failedAttempts.put(config.socket.getPort(), 1);
+                }
+                System.out.println("Start on port " + config.socket.getPort() + " failed " + failedAttempts.get(config.socket.getPort()) + "x");
+                startMultipleServers(config, retries - 1, minBackoff, maxBackoff);
+            }
+        } else {
+            throw new IOException("Cannot start server - all ports are used");
+        }
+    }
+
+    private static void backoff(int min, int max, String source) throws InterruptedException {
+        int backoff = RNG.nextInt(max - min + 1) + min;
+        System.out.println("Backing off at " + source + " for " + backoff + "ms");
+        Thread.sleep(backoff);
+    }
+
+    public static InetSocketAddress createInetSocket(String givenHost, int port) {
+
+        InetSocketAddress socket;
+        if (givenHost != null && !givenHost.isEmpty()) {
+            socket = new InetSocketAddress(givenHost, port);
+        } else {
+            socket = new InetSocketAddress("0.0.0.0", port);
+        }
+        return socket;
+    }
+
+    /**
+     * Parse the Java Agent configuration. The arguments are typically specified to the JVM as a javaagent as
+     * {@code -javaagent:/path/to/agent.jar=<CONFIG>}. This method parses the {@code <CONFIG>} portion.
+     *
+     * @param args provided agent args
+     * @return configuration to use for our application
+     */
+    public static Config parseConfig(String args) {
+        String[] requiredParameters = "portStart,portEnd,configFile".split(",");
+
+        String[] argsSplits = args.split(",");
+        HashMap<String, String> configMap = new HashMap<String, String>();
+        for (String arg : argsSplits) {
+            String[] kv = arg.split("=");
+            configMap.put(kv[0], kv[1]);
+        }
+
+        for (String requiredParameter : requiredParameters) {
+            if (!configMap.containsKey(requiredParameter)) {
+                throw new IllegalArgumentException("Argument " + requiredParameter + " is missing");
+            }
+        }
+
+        // Defaults
+        if (!configMap.containsKey("timeout")) {
+            configMap.put("timeout", "500");
+        }
+
+        if (!configMap.containsKey("backoffMin")) {
+            configMap.put("backoffMin", "2000");
+        }
+
+        if (!configMap.containsKey("backoffMax")) {
+            configMap.put("backoffMax", "4000");
+        }
+
+        return new Config(configMap.get("hostname"),
+                Integer.parseInt(configMap.get("portStart")),
+                Integer.parseInt(configMap.get("portEnd")),
+                Integer.parseInt(configMap.get("timeout")),
+                Integer.parseInt(configMap.get("backoffMin")),
+                Integer.parseInt(configMap.get("backoffMax")),
+                configMap.get("configFile"),
+                createInetSocket(configMap.get("hostname"), Integer.parseInt(configMap.get("portStart"))));
+    }
+
+    static class Config {
+        String host;
+        int portStart;
+        int portEnd;
+        int timeout;
+        int backoffMin;
+        int backoffMax;
+        String configFile;
+        InetSocketAddress socket;
+
+        Config(String host, int portStart, int portEnd, int timeout, int backoffMin, int backoffMax, String configFile, InetSocketAddress socket) {
+            this.host = host;
+            this.portStart = portStart;
+            this.portEnd = portEnd;
+            this.timeout = timeout;
+            this.backoffMin = backoffMin;
+            this.backoffMax = backoffMax;
+            this.configFile = configFile;
+            this.socket = socket;
+        }
+
+        public void setSocket(InetSocketAddress socket) {
+            this.socket = socket;
+        }
+
+        @Override
+        public String toString() {
+            return MessageFormat.format("Address: {0}:{1}{2} configFile: {3}, timout: {4}, backoff (min: {5}, max: {6})", host, portStart, portEnd, configFile, timeout, backoffMin, backoffMax);
+        }
+    }
+}

--- a/jmx_prometheus_javaagent_common/src/test/java/io/prometheus/jmx/JavaAgentMultiPortTest.java
+++ b/jmx_prometheus_javaagent_common/src/test/java/io/prometheus/jmx/JavaAgentMultiPortTest.java
@@ -1,0 +1,133 @@
+package io.prometheus.jmx;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+
+public class JavaAgentMultiPortTest {
+    static final String IFC = "0.0.0.0";
+    static final String HOST = "some_host.dc";
+    static final int RESTARTS = 3, minBackoff = 0, maxBackoff = 100;
+    // hostname=localhost,portStart=1000,portEnd=1010,timeout=500,backoffMin=2000,backoffMax=4000,configFile=/some/path.yaml
+    @Test(expected = Exception.class)
+    public void testFailureOnOriginalConfig() {
+        JavaAgentMultiPort.Config config1 = JavaAgentMultiPort.parseConfig("some_host.dc:111:./config_file.yaml");
+    }
+    @Test
+    public void testConfigParsing() {
+        JavaAgentMultiPort.Config config = JavaAgentMultiPort.parseConfig("hostname=some_host.dc,portStart=222,portEnd=333,timeout=500,backoffMin=2000,backoffMax=4000,configFile=/some/path.yaml");
+
+        Assert.assertEquals(222, config.portStart);
+        Assert.assertEquals(333, config.portEnd);
+        Assert.assertEquals(500, config.timeout);
+        Assert.assertEquals(2000, config.backoffMin);
+        Assert.assertEquals(4000, config.backoffMax);
+        Assert.assertEquals("/some/path.yaml", config.configFile);
+        Assert.assertEquals(HOST, config.host);
+        Assert.assertEquals(new InetSocketAddress(HOST, 222), config.socket);
+    }
+
+
+    @Test
+    public void testMinimalConfigParsing() {
+        JavaAgentMultiPort.Config config = JavaAgentMultiPort.parseConfig("portStart=222,portEnd=333,configFile=/some/path.yaml");
+
+        Assert.assertEquals(222, config.portStart);
+        Assert.assertEquals(333, config.portEnd);
+        Assert.assertEquals(500, config.timeout);
+        Assert.assertEquals(2000, config.backoffMin);
+        Assert.assertEquals(4000, config.backoffMax);
+        Assert.assertEquals("/some/path.yaml", config.configFile);
+        Assert.assertNull(config.host);
+        Assert.assertEquals(new InetSocketAddress(IFC, 222), config.socket);
+    }
+
+    @Test
+    public void testPartialConfigParsing() {
+        JavaAgentMultiPort.Config config = JavaAgentMultiPort.parseConfig("portStart=222,portEnd=333,backoffMin=500,configFile=/some/path.yaml");
+
+        Assert.assertEquals(222, config.portStart);
+        Assert.assertEquals(333, config.portEnd);
+        Assert.assertEquals(500, config.timeout);
+        Assert.assertEquals(500, config.backoffMin);
+        Assert.assertEquals(4000, config.backoffMax);
+        Assert.assertEquals("/some/path.yaml", config.configFile);
+        Assert.assertNull(config.host);
+        Assert.assertEquals(new InetSocketAddress(IFC, 222), config.socket);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testIncompleteConfig1() {
+        JavaAgentMultiPort.parseConfig("portEnd=333,timeout=500,backoffMin=2000,backoffMax=4000,configFile=/some/path.yaml");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIncompleteConfig2() {
+        JavaAgentMultiPort.parseConfig("portStart=222,timeout=500,backoffMin=2000,backoffMax=4000,configFile=/some/path.yaml");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIncompelteConfig3() {
+        JavaAgentMultiPort.parseConfig("portStart=222,portEnd=333,timeout=500,backoffMin=2000,backoffMax=4000");
+    }
+
+    @Test
+    public void testSingleServerStart() throws IOException, InterruptedException {
+        JavaAgentMultiPort.startMultipleServers(new JavaAgentMultiPort.Config(IFC, 2000, 2000,500,2000,4000, "some_file.yaml", JavaAgentMultiPort.createInetSocket(IFC, 2000)), RESTARTS, minBackoff, maxBackoff);
+
+        Socket socket = new Socket();
+        final InetAddress inetAddress = InetAddress.getByName(IFC);
+        final InetSocketAddress inetSocketAddress = new InetSocketAddress(inetAddress, 2000);
+        socket.connect(inetSocketAddress, 500);
+        Assert.assertTrue(socket.isConnected());
+        socket.close();
+    }
+
+    /**
+     * Tests port rolling
+     * It has to be able to open 5 server with on ports between 2000 and 2004.
+     * <p>
+     * Calling JavaAgentMultiPort.startServer() instead of JavaAgentMultiPort.premain(), because it is not able to register multiple
+     * server from one JVM. Which is not a issue for us, because we won't be doing that. The problem we are solving
+     * with this is socket binding.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testServerStarts() throws IOException, InterruptedException {
+        JavaAgentMultiPort.startMultipleServers(new JavaAgentMultiPort.Config(IFC, 3000, 3004, 500, 2000, 4000, "some_file.yaml", JavaAgentMultiPort.createInetSocket(IFC, 3000)), RESTARTS, minBackoff, maxBackoff);
+        JavaAgentMultiPort.startMultipleServers(new JavaAgentMultiPort.Config(IFC, 3000, 3004, 500, 2000, 4000, "some_file.yaml", JavaAgentMultiPort.createInetSocket(IFC, 3000)), RESTARTS, minBackoff, maxBackoff);
+        JavaAgentMultiPort.startMultipleServers(new JavaAgentMultiPort.Config(IFC, 3000, 3004, 500, 2000, 4000, "some_file.yaml", JavaAgentMultiPort.createInetSocket(IFC, 3000)), RESTARTS, minBackoff, maxBackoff);
+        JavaAgentMultiPort.startMultipleServers(new JavaAgentMultiPort.Config(IFC, 3000, 3004, 500, 2000, 4000, "some_file.yaml", JavaAgentMultiPort.createInetSocket(IFC, 3000)), RESTARTS, minBackoff, maxBackoff);
+        JavaAgentMultiPort.startMultipleServers(new JavaAgentMultiPort.Config(IFC, 3000, 3004, 500, 2000, 4000, "some_file.yaml", JavaAgentMultiPort.createInetSocket(IFC, 3000)), RESTARTS, minBackoff, maxBackoff);
+
+        for (int i = 3000; i <= 3004; i++) {
+            Socket socket = new Socket();
+            final InetAddress inetAddress = InetAddress.getByName(IFC);
+            final InetSocketAddress inetSocketAddress = new InetSocketAddress(inetAddress, i);
+            socket.connect(inetSocketAddress, 500);
+            Assert.assertTrue(socket.isConnected());
+            socket.close();
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void testOverbookedServerStart() throws IOException, InterruptedException {
+        JavaAgentMultiPort.startMultipleServers(new JavaAgentMultiPort.Config(IFC, 4000, 4001,500, 2000,4000, "some_file.yaml", JavaAgentMultiPort.createInetSocket(IFC, 4000)), RESTARTS, minBackoff, maxBackoff);
+        JavaAgentMultiPort.startMultipleServers(new JavaAgentMultiPort.Config(IFC, 4000, 4001,500, 2000,4000, "some_file.yaml", JavaAgentMultiPort.createInetSocket(IFC, 4000)), RESTARTS, minBackoff, maxBackoff);
+
+        for (int i = 4000; i <= 4001; i++) {
+            Socket socket = new Socket();
+            final InetAddress inetAddress = InetAddress.getByName(IFC);
+            final InetSocketAddress inetSocketAddress = new InetSocketAddress(inetAddress, i);
+            socket.connect(inetSocketAddress, 500);
+            Assert.assertTrue(socket.isConnected());
+            socket.close();
+        }
+        JavaAgentMultiPort.startMultipleServers(new JavaAgentMultiPort.Config(IFC, 4000, 4001,500,2000,4000, "some_file.yaml", JavaAgentMultiPort.createInetSocket(IFC, 4000)), RESTARTS, minBackoff, maxBackoff);
+    }
+}

--- a/jmx_prometheus_javaagent_multiport/README.txt
+++ b/jmx_prometheus_javaagent_multiport/README.txt
@@ -1,0 +1,3 @@
+Why does this module not have any source code?
+
+This module re-packages the JAR from the java6 version, replacing the SnakeYaml dependency with the latest version (which requires Java >= 7).

--- a/jmx_prometheus_javaagent_multiport/pom.xml
+++ b/jmx_prometheus_javaagent_multiport/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.prometheus.jmx</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.18.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jmx_prometheus_javaagent_multiport</artifactId>
+    <name>Prometheus JMX Exporter - Java Agent MultiPort</name>
+    <description>
+        See https://github.com/prometheus/jmx_exporter/blob/master/README.md
+    </description>
+    <url>http://github.com/prometheus/jmx_exporter</url>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.prometheus.jmx</groupId>
+            <artifactId>jmx_prometheus_javaagent_common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <shadedPattern>io.prometheus.jmx.shaded.</shadedPattern>
+                                    <includes>
+                                        <include>org.yaml.**</include>
+                                        <include>io.prometheus.client.**</include>
+                                    </includes>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Premain-Class>io.prometheus.jmx.JavaAgentMultiPort</Premain-Class>
+                                        <Agent-Class>io.prometheus.jmx.JavaAgentMultiPort</Agent-Class>
+                                        <Implementation-Version>${project.version}</Implementation-Version>
+                                        <Implementation-Title>${project.artifactId}</Implementation-Title>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
+                            <createSourcesJar>true</createSourcesJar>
+                            <shadeSourcesContent>true</shadeSourcesContent>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <!-- Every artifact on Maven central needs a javadoc JAR. -->
+                <!-- As this module does not have its own Java sources, we include the javadoc from the dependency. -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <includeDependencySources>true</includeDependencySources>
+                            <dependencySourceIncludes>
+                                <dependencySourceInclude>${project.groupId}:*</dependencySourceInclude>
+                            </dependencySourceIncludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/jmx_prometheus_javaagent_multiport/version-rules.xml
+++ b/jmx_prometheus_javaagent_multiport/version-rules.xml
@@ -1,0 +1,6 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 https://www.mojohaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+    <rules>
+    </rules>
+</ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <module>jmx_prometheus_javaagent_common</module>
         <module>jmx_prometheus_javaagent_java6</module>
         <module>jmx_prometheus_javaagent</module>
+        <module>jmx_prometheus_javaagent_multiport</module>
         <module>integration_test_suite</module>
     </modules>
 


### PR DESCRIPTION
## Why this was created
We needed a way to collect JMX metrics from Apache Spark jobs running on AWS EMR.

The way you tell Spark to expose these metrics is
```
spark submit ...
--conf "spark.executor.extraJavaOptions=-javaagent:./jmx_prometheus_javaagent-0.17.2.jar=<1 specific port>:<config file>"
```
This works fine as long as you have 1 JVM with 1 agent exposing the metrics as it will open the webserver on a specific port.
When you have 2 executors on 1 machine, one will not start (you cannot start 2 webservers on 1 port) and the job will crash.

## The enhancement

1. You can define a range of ports, in our case we use 39100-39115. Some of the ports are wasted as a headroom. Nevertheless, it needs a continuous block/range of ports.
2. It will not fail, when it cannot start a webserver. It will try to pick next port in the range. It would fail if your port range have 5 ports, but you would want to start 10 exporters on that machine.

The exporters will compete for resource (port) and they act independently. For this there are backoff times and retries.

On driver/executor stdout it looks like this
```
Backing off at server start for 1218ms
Looking up free port. Checking: 39100, remaining ports in range: 16
Port 39100 is used. Trying next one.
Looking up free port. Checking: 39101, remaining ports in range: 15
Found free port 39101
Trying to start JMX agent on 39101
Started JMX agent on 39101. (retries left: 16)
```
fixes #627 