### PR TITLE
Add support for JMX TabularData that uses a CompositeData key

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -274,12 +274,24 @@ class JmxScraper {
                     for (String idx : rowKeys) {
                         Object obj = composite.get(idx);
                         if (obj != null) {
+
                             // Nested tabulardata will repeat the 'key' label, so
                             // append a suffix to distinguish each.
                             while (l2s.containsKey(idx)) {
-                              idx = idx + "_";
+                                idx = idx + "_";
                             }
-                            l2s.put(idx, obj.toString());
+
+                            if (obj instanceof CompositeData) {
+                                // TabularData key is a composite key
+                                CompositeData compositeKey = (CompositeData) obj;
+                                CompositeType ct = compositeKey.getCompositeType();
+                                for (final String compositeKeyIdx : ct.keySet()) {
+                                    l2s.put(idx + "_" + compositeKeyIdx, compositeKey.get(compositeKeyIdx).toString());
+                                }
+                            } else {
+                                // TabularData key is an Open type key
+                                l2s.put(idx, obj.toString());
+                            }
                         }
                     }
                     for(String valueIdx : valueKeys) {

--- a/collector/src/test/java/io/prometheus/jmx/ExistDbMXBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/ExistDbMXBean.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2022-2023 The Prometheus jmx_exporter Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prometheus.jmx;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.util.Map;
+import java.util.TreeMap;
+
+public interface ExistDbMXBean {
+    Map<QueryKey, RunningQuery> getRunningQueries();
+
+     class QueryKey implements Comparable<QueryKey> {
+        private final int id;
+        private final String path;
+
+        public QueryKey(final int id, final String path) {
+            this.id = id;
+            this.path = path;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public boolean equals(final Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (other == null || getClass() != other.getClass()) {
+                return false;
+            }
+
+            QueryKey queryKey = (QueryKey) other;
+            if (id != queryKey.id) {
+                return false;
+            }
+            return path.equals(queryKey.path);
+        }
+
+        public int hashCode() {
+            int result = id;
+            result = 31 * result + path.hashCode();
+            return result;
+        }
+
+        public int compareTo(final QueryKey other) {
+            if (other == null) {
+                return 1;
+            }
+
+            return path.compareTo(other.path);
+        }
+    }
+
+    class RunningQuery {
+        private final int id;
+        private final String path;
+
+        private final long startedAtTime;
+
+        public RunningQuery(final int id, final String path, final long startedAtTime) {
+            this.id = id;
+            this.path = path;
+            this.startedAtTime = startedAtTime;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public long getStartedAtTime() {
+            return startedAtTime;
+        }
+
+        public long getElapsedTime() {
+            return System.currentTimeMillis() - startedAtTime;
+        }
+    }
+}
+
+class ExistDb implements ExistDbMXBean {
+
+    public static void registerBean(MBeanServer mbs)
+            throws javax.management.JMException {
+        ObjectName mxbeanName = new ObjectName(
+                "org.exist.management.exist:type=ProcessReport");
+        ExistDb mxbean = new ExistDb();
+        mbs.registerMBean(mxbean, mxbeanName);
+    }
+
+    public Map<QueryKey, RunningQuery> getRunningQueries() {
+        final Map<QueryKey, RunningQuery> queries = new TreeMap<QueryKey, RunningQuery>();
+
+        final RunningQuery runningQuery1 = new RunningQuery(1, "/db/query1.xq", System.currentTimeMillis());
+        final RunningQuery runningQuery2 = new RunningQuery(2, "/db/query2.xq", System.currentTimeMillis());
+
+        queries.put(new QueryKey(runningQuery1.getId(), runningQuery1.getPath()), runningQuery1);
+        queries.put(new QueryKey(runningQuery2.getId(), runningQuery2.getPath()), runningQuery2);
+
+        return queries;
+    }
+}

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -36,6 +36,7 @@ public class JmxCollectorTest {
         CassandraMetrics.registerBean(mbs);
         Hadoop.registerBean(mbs);
         HadoopDataNode.registerBean(mbs);
+        ExistDb.registerBean(mbs);
         BeanWithEnum.registerBean(mbs);
 
         TomcatServlet.registerBean(mbs);
@@ -166,6 +167,13 @@ public class JmxCollectorTest {
     public void nestedTabularDataTest() throws Exception {
       JmxCollector jc = new JmxCollector("---").register(registry);
       assertEquals(338, registry.getSampleValue("Hadoop_DataNodeInfo_DatanodeNetworkCounts", new String[]{"service", "key", "key_"}, new String[]{"DataNode", "1.2.3.4", "networkErrors"}), .001);
+    }
+
+    @Test
+    public void tabularDataCompositeKeyTest() throws Exception {
+        JmxCollector jc = new JmxCollector("---").register(registry);
+        assertEquals(1, registry.getSampleValue("org_exist_management_exist_ProcessReport_RunningQueries_id", new String[]{"key_id", "key_path"}, new String[]{"1", "/db/query1.xq"}), .001);
+        assertEquals(2, registry.getSampleValue("org_exist_management_exist_ProcessReport_RunningQueries_id", new String[]{"key_id", "key_path"}, new String[]{"2", "/db/query2.xq"}), .001);
     }
 
     @Test

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/CompositeKeyDataTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/CompositeKeyDataTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2023 The Prometheus jmx_exporter Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prometheus.jmx.test;
+
+import io.prometheus.jmx.test.support.ContentConsumer;
+import io.prometheus.jmx.test.support.HealthyRequest;
+import io.prometheus.jmx.test.support.HealthyResponse;
+import io.prometheus.jmx.test.support.MetricsRequest;
+import io.prometheus.jmx.test.support.MetricsResponse;
+import io.prometheus.jmx.test.support.OpenMetricsRequest;
+import io.prometheus.jmx.test.support.OpenMetricsResponse;
+import io.prometheus.jmx.test.support.PrometheusMetricsRequest;
+import io.prometheus.jmx.test.support.PrometheusMetricsResponse;
+import org.antublue.test.engine.api.TestEngine;
+
+import java.util.Collection;
+
+import static io.prometheus.jmx.test.support.MetricsAssertions.assertThatMetricIn;
+import static io.prometheus.jmx.test.support.RequestResponseAssertions.assertThatResponseForRequest;
+
+public class CompositeKeyDataTest extends BaseTest implements ContentConsumer {
+
+    @TestEngine.Test
+    public void testHealthy() {
+        assertThatResponseForRequest(new HealthyRequest(testState.httpClient()))
+                .isSuperset(HealthyResponse.RESULT_200);
+    }
+
+    @TestEngine.Test
+    public void testMetrics() {
+        assertThatResponseForRequest(new MetricsRequest(testState.httpClient()))
+                .isSuperset(MetricsResponse.RESULT_200)
+                .dispatch(this);
+    }
+
+    @TestEngine.Test
+    public void testMetricsOpenMetricsFormat() {
+        assertThatResponseForRequest(new OpenMetricsRequest(testState.httpClient()))
+                .isSuperset(OpenMetricsResponse.RESULT_200)
+                .dispatch(this);
+    }
+
+    @TestEngine.Test
+    public void testMetricsPrometheusFormat() {
+        assertThatResponseForRequest(new PrometheusMetricsRequest(testState.httpClient()))
+                .isSuperset(PrometheusMetricsResponse.RESULT_200)
+                .dispatch(this);
+    }
+
+    @Override
+    public void accept(String content) {
+        Collection<Metric> metrics = MetricsParser.parse(content);
+
+        assertThatMetricIn(metrics)
+                .withName("org_exist_management_exist_ProcessReport_RunningQueries_id")
+                .withLabel("key_id", "1")
+                .withLabel("key_path", "/db/query1.xq")
+                .exists();
+
+        assertThatMetricIn(metrics)
+                .withName("org_exist_management_exist_ProcessReport_RunningQueries_id")
+                .withLabel("key_id", "2")
+                .withLabel("key_path", "/db/query2.xq")
+                .exists();
+    }
+}

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/CompositeKeyDataTest/JavaAgent/application.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/CompositeKeyDataTest/JavaAgent/application.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+java \
+  -Xmx512M \
+  -javaagent:jmx_prometheus_javaagent.jar=8888:exporter.yaml \
+  -jar jmx_example_application.jar

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/CompositeKeyDataTest/JavaAgent/exporter.yaml
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/CompositeKeyDataTest/JavaAgent/exporter.yaml
@@ -1,0 +1,2 @@
+rules:
+  - pattern: ".*"

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/CompositeKeyDataTest/Standalone/application.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/CompositeKeyDataTest/Standalone/application.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+java \
+  -Xmx512M \
+  -Dcom.sun.management.jmxremote=true \
+  -Dcom.sun.management.jmxremote.authenticate=false \
+  -Dcom.sun.management.jmxremote.local.only=false \
+  -Dcom.sun.management.jmxremote.port=9999 \
+  -Dcom.sun.management.jmxremote.registry.ssl=false \
+  -Dcom.sun.management.jmxremote.rmi.port=9999 \
+  -Dcom.sun.management.jmxremote.ssl.need.client.auth=false \
+  -Dcom.sun.management.jmxremote.ssl=false \
+  -jar jmx_example_application.jar

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/CompositeKeyDataTest/Standalone/exporter.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/CompositeKeyDataTest/Standalone/exporter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+java \
+  -Xmx512M \
+  -jar jmx_prometheus_httpserver.jar 8888 exporter.yaml

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/CompositeKeyDataTest/Standalone/exporter.yaml
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/CompositeKeyDataTest/Standalone/exporter.yaml
@@ -1,0 +1,3 @@
+hostPort: application:9999
+rules:
+  - pattern: ".*"

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/ExistDbMXBean.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/ExistDbMXBean.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2022-2023 The Prometheus jmx_exporter Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prometheus.jmx;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.util.Map;
+import java.util.TreeMap;
+
+public interface ExistDbMXBean {
+    Map<QueryKey, RunningQuery> getRunningQueries();
+
+     class QueryKey implements Comparable<QueryKey> {
+        private final int id;
+        private final String path;
+
+        public QueryKey(final int id, final String path) {
+            this.id = id;
+            this.path = path;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public boolean equals(final Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (other == null || getClass() != other.getClass()) {
+                return false;
+            }
+
+            QueryKey queryKey = (QueryKey) other;
+            if (id != queryKey.id) {
+                return false;
+            }
+            return path.equals(queryKey.path);
+        }
+
+        public int hashCode() {
+            int result = id;
+            result = 31 * result + path.hashCode();
+            return result;
+        }
+
+        public int compareTo(final QueryKey other) {
+            if (other == null) {
+                return 1;
+            }
+
+            return path.compareTo(other.path);
+        }
+    }
+
+    class RunningQuery {
+        private final int id;
+        private final String path;
+
+        private final long startedAtTime;
+
+        public RunningQuery(final int id, final String path, final long startedAtTime) {
+            this.id = id;
+            this.path = path;
+            this.startedAtTime = startedAtTime;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public long getStartedAtTime() {
+            return startedAtTime;
+        }
+
+        public long getElapsedTime() {
+            return System.currentTimeMillis() - startedAtTime;
+        }
+    }
+}
+
+class ExistDb implements ExistDbMXBean {
+
+    public static void registerBean(MBeanServer mbs)
+            throws javax.management.JMException {
+        ObjectName mxbeanName = new ObjectName(
+                "org.exist.management.exist:type=ProcessReport");
+        ExistDb mxbean = new ExistDb();
+        mbs.registerMBean(mxbean, mxbeanName);
+    }
+
+    public Map<QueryKey, RunningQuery> getRunningQueries() {
+        final Map<QueryKey, RunningQuery> queries = new TreeMap<QueryKey, RunningQuery>();
+
+        final RunningQuery runningQuery1 = new RunningQuery(1, "/db/query1.xq", System.currentTimeMillis());
+        final RunningQuery runningQuery2 = new RunningQuery(2, "/db/query2.xq", System.currentTimeMillis());
+
+        queries.put(new QueryKey(runningQuery1.getId(), runningQuery1.getPath()), runningQuery1);
+        queries.put(new QueryKey(runningQuery2.getId(), runningQuery2.getPath()), runningQuery2);
+
+        return queries;
+    }
+}

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/JmxExampleApplication.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/JmxExampleApplication.java
@@ -37,6 +37,8 @@ public class JmxExampleApplication {
         ObjectName autoIncrementingMBan = new ObjectName("io.prometheus.jmx:type=autoIncrementing");
         server.registerMBean(new AutoIncrementing(), autoIncrementingMBan);
 
+        ExistDb.registerBean(server);
+
         System.out.println(
                 String.format("%s | %s | INFO | %s | %s",
                         SIMPLE_DATE_FORMAT.format(new Date()),


### PR DESCRIPTION
Previously the implementation for JMX TabularData did not support TabularData that used composite keys. This PR adds support for that. It also adds a test that should show that this now works.

In eXist-db, we often export data via JMX that uses composite keys for Tabular Data. There is nothing in this PR that is specific to eXist-db, and I suspect the improved functionality in this PR will be be generally useful for all JMX users.