### PR TITLE
Changed integration test build

### DIFF
--- a/integration_test_suite/integration_tests/pom.xml
+++ b/integration_test_suite/integration_tests/pom.xml
@@ -28,7 +28,6 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jmx.core.root>../..</jmx.core.root>
         <antublue.test.engine.version>5.0.0</antublue.test.engine.version>
         <!-- smoke test containers -->
         <docker.image.names/>
@@ -60,36 +59,6 @@
                     <goals>
                         <goal>clean</goal>
                     </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.coderplus.maven.plugins</groupId>
-                <artifactId>copy-rename-maven-plugin</artifactId>
-                <version>1.0.1</version>
-                <executions>
-                    <execution>
-                        <id>copy-resources</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <fileSets>
-                                <fileSet>
-                                    <sourceFile>${jmx.core.root}/jmx_prometheus_javaagent/target/jmx_prometheus_javaagent-${project.version}.jar</sourceFile>
-                                    <destinationFile>src/test/resources/common/jmx_prometheus_javaagent.jar</destinationFile>
-                                </fileSet>
-                                <fileSet>
-                                    <sourceFile>${jmx.core.root}/jmx_prometheus_httpserver/target/jmx_prometheus_httpserver-${project.version}.jar</sourceFile>
-                                    <destinationFile>src/test/resources/common/jmx_prometheus_httpserver.jar</destinationFile>
-                                </fileSet>
-                                <fileSet>
-                                    <sourceFile>../jmx_example_application/target/jmx_example_application.jar</sourceFile>
-                                    <destinationFile>src/test/resources/common/jmx_example_application.jar</destinationFile>
-                                </fileSet>
-                            </fileSets>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integration_test_suite/jmx_example_application/pom.xml
+++ b/integration_test_suite/jmx_example_application/pom.xml
@@ -53,6 +53,28 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.coderplus.maven.plugins</groupId>
+                <artifactId>copy-rename-maven-plugin</artifactId>
+                <version>1.0.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <fileSets>
+                                <fileSet>
+                                    <sourceFile>${project.build.directory}/${project.build.finalName}.jar</sourceFile>
+                                    <destinationFile>../integration_tests/src/test/resources/common/jmx_example_application.jar</destinationFile>
+                                </fileSet>
+                            </fileSets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/jmx_prometheus_httpserver/pom.xml
+++ b/jmx_prometheus_httpserver/pom.xml
@@ -127,6 +127,28 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.coderplus.maven.plugins</groupId>
+                <artifactId>copy-rename-maven-plugin</artifactId>
+                <version>1.0.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <fileSets>
+                                <fileSet>
+                                    <sourceFile>${project.build.directory}/${project.build.finalName}.jar</sourceFile>
+                                    <destinationFile>../integration_test_suite/integration_tests/src/test/resources/common/jmx_prometheus_httpserver.jar</destinationFile>
+                                </fileSet>
+                            </fileSets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -94,7 +94,6 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <!-- Every artifact on Maven central needs a javadoc JAR. -->
                 <!-- As this module does not have its own Java sources, we include the javadoc from the dependency. -->
@@ -111,6 +110,28 @@
                             <dependencySourceIncludes>
                                 <dependencySourceInclude>${project.groupId}:*</dependencySourceInclude>
                             </dependencySourceIncludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.coderplus.maven.plugins</groupId>
+                <artifactId>copy-rename-maven-plugin</artifactId>
+                <version>1.0.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <fileSets>
+                                <fileSet>
+                                    <sourceFile>${project.build.directory}/${project.build.finalName}.jar</sourceFile>
+                                    <destinationFile>../integration_test_suite/integration_tests/src/test/resources/common/jmx_prometheus_javaagent.jar</destinationFile>
+                                </fileSet>
+                            </fileSets>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
These changes make copying the `jmx_prometheus_javaagent.jar`, `jmx_prometheus_httpserver.jar`, and `jmx_example_application.jar` a concern of their respective projects.

This allows patching of the `integration_tests` jars and building/running the integration test suite on older or pre-release jars.