### PR TITLE
Added code to skip RuntimeMXBean attributes

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -186,6 +186,20 @@ class JmxScraper {
         for (Object object : attributes) {
             if (object instanceof Attribute) {
                 Attribute attribute = (Attribute) object;
+                String attributeName = attribute.getName();
+                if (mBeanName.toString().equals("java.lang:type=Runtime")
+                        && (attributeName.equalsIgnoreCase("SystemProperties")
+                        || attributeName.equalsIgnoreCase("ClassPath")
+                        || attributeName.equalsIgnoreCase("BootClassPath"))
+                        || attributeName.equalsIgnoreCase("LibraryPath")) {
+                    // Skip attributes for the "java.lang:type=Runtime" MBean because
+                    // getting the values is expensive and the values are ultimately ignored
+                    continue;
+                } else if (mBeanName.toString().equals("jdk.management.jfr:type=FlightRecorder")) {
+                    // Skip the FlightRecorderMXBean
+                    continue;
+                }
+
                 MBeanAttributeInfo mBeanAttributeInfo = name2MBeanAttributeInfo.get(attribute.getName());
                 logScrape(mBeanName, mBeanAttributeInfo, "process");
                 processBeanValue(


### PR DESCRIPTION
Added code to skip RuntimeMXBean attributes `SystemProperties`, `ClassPath`, `BootClassPath`, and `LibraryPath` since the calls to get the attribute values are very expensive the values are ultimately ignored.