### PR TITLE
Fix Exceptions are not handled on premain

### DIFF
--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -23,6 +23,7 @@ import io.prometheus.jmx.common.http.ConfigurationException;
 import io.prometheus.jmx.common.http.HTTPServerFactory;
 import java.io.File;
 import java.lang.instrument.Instrumentation;
+import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -62,7 +63,10 @@ public class JavaAgent {
                                     CollectorRegistry.defaultRegistry,
                                     true,
                                     new File(config.file));
-        } catch (ConfigurationException e) {
+        } catch (BindException e) {
+            System.err.println("Jmx-exporter listen port bind failed : " + e.getMessage());
+            System.exit(1);
+        }  catch (ConfigurationException e) {
             System.err.println("Configuration Exception : " + e.getMessage());
             System.exit(1);
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
Prev code would cause jvm to crash as Exception uncatched in javaagent premain. 
So this commit make the BindException checked and output definite error and then exit expectedly.