### PR TITLE
Add example config file for kafka kraft mode metrics

### DIFF
--- a/example_configs/kafka-kraft-3_0_0.yml
+++ b/example_configs/kafka-kraft-3_0_0.yml
@@ -1,0 +1,137 @@
+lowercaseOutputName: true
+
+rules:
+# Special cases and very specific rules
+- pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
+  name: kafka_server_$1_$2
+  type: GAUGE
+  labels:
+    clientId: "$3"
+    topic: "$4"
+    partition: "$5"
+- pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
+  name: kafka_server_$1_$2
+  type: GAUGE
+  labels:
+    clientId: "$3"
+    broker: "$4:$5"
+- pattern : kafka.coordinator.(\w+)<type=(.+), name=(.+)><>Value
+  name: kafka_coordinator_$1_$2_$3
+  type: GAUGE
+# Kraft current state info metric rule
+- pattern: "kafka.server<type=raft-metrics><>current-state: ([a-z]+)"
+  name: kafka_server_raft_metrics_current_state_info
+  type: GAUGE
+  value: 1
+  labels:
+    "state": "$1"
+# Kraft specific rules for raft-metrics, raft-channel-metrics, broker-metadata-metrics
+- pattern: kafka.server<type=(.+)><>([a-z-]+)-total
+  name: kafka_server_$1_$2_total
+  type: COUNTER
+- pattern: kafka.server<type=(.+)><>([a-z-]+)
+  name: kafka_server_$1_$2
+  type: GAUGE
+
+# Generic per-second counters with 0-2 key/value pairs
+- pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+), (.+)=(.+)><>Count
+  name: kafka_$1_$2_$3_total
+  type: COUNTER
+  labels:
+    "$4": "$5"
+    "$6": "$7"
+- pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+)><>Count
+  name: kafka_$1_$2_$3_total
+  type: COUNTER
+  labels:
+    "$4": "$5"
+- pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count
+  name: kafka_$1_$2_$3_total
+  type: COUNTER
+
+# Quota specific rules
+- pattern: kafka.server<type=(.+), user=(.+), client-id=(.+)><>([a-z-]+)
+  name: kafka_server_quota_$4
+  type: GAUGE
+  labels:
+    resource: "$1"
+    user: "$2"
+    clientId: "$3"
+- pattern: kafka.server<type=(.+), client-id=(.+)><>([a-z-]+)
+  name: kafka_server_quota_$3
+  type: GAUGE
+  labels:
+    resource: "$1"
+    clientId: "$2"
+- pattern: kafka.server<type=(.+), user=(.+)><>([a-z-]+)
+  name: kafka_server_quota_$3
+  type: GAUGE
+  labels:
+    resource: "$1"
+    user: "$2"
+
+# Generic gauges with 0-2 key/value pairs
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Value
+  name: kafka_$1_$2_$3
+  type: GAUGE
+  labels:
+    "$4": "$5"
+    "$6": "$7"
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Value
+  name: kafka_$1_$2_$3
+  type: GAUGE
+  labels:
+    "$4": "$5"
+- pattern: kafka.(\w+)<type=(.+), name=(.+)><>Value
+  name: kafka_$1_$2_$3
+  type: GAUGE
+
+# Emulate Prometheus 'Summary' metrics for the exported 'Histogram's.
+#
+# Note that these are missing the '_sum' metric!
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Count
+  name: kafka_$1_$2_$3_count
+  type: COUNTER
+  labels:
+    "$4": "$5"
+    "$6": "$7"
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*), (.+)=(.+)><>(\d+)thPercentile
+  name: kafka_$1_$2_$3
+  type: GAUGE
+  labels:
+    "$4": "$5"
+    "$6": "$7"
+    quantile: "0.$8"
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Count
+  name: kafka_$1_$2_$3_count
+  type: COUNTER
+  labels:
+    "$4": "$5"
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*)><>(\d+)thPercentile
+  name: kafka_$1_$2_$3
+  type: GAUGE
+  labels:
+    "$4": "$5"
+    quantile: "0.$6"
+- pattern: kafka.(\w+)<type=(.+), name=(.+)><>Count
+  name: kafka_$1_$2_$3_count
+  type: COUNTER
+- pattern: kafka.(\w+)<type=(.+), name=(.+)><>(\d+)thPercentile
+  name: kafka_$1_$2_$3
+  type: GAUGE
+  labels:
+    quantile: "0.$4"
+
+# Generic gauges for MeanRate Percent
+# Ex) kafka.server<type=KafkaRequestHandlerPool, name=RequestHandlerAvgIdlePercent><>MeanRate
+- pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>MeanRate
+  name: kafka_$1_$2_$3_percent
+  type: GAUGE
+- pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>Value
+  name: kafka_$1_$2_$3_percent
+  type: GAUGE
+- pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*, (.+)=(.+)><>Value
+  name: kafka_$1_$2_$3_percent
+  type: GAUGE
+  labels:
+    "$4": "$5"


### PR DESCRIPTION
@dhoard 

After looking issue #881 and pr #793, i created this pr.

The kraft-related metrics are `raft-metrics`, `raft-channel-metrics`, and `broker-metadata-metrics`, and the reason why these metrics could not be collected with the kafka-2_0_0.yml rules is that the name was set to attrName.

<img width="500" alt="jconsole-raft-metrics" src="https://github.com/prometheus/jmx_exporter/assets/44857109/00bdadb7-eda5-4f2f-ae51-5541d629984f">

I added the following rules based on kafka-2_0_0.yml file for these metrics.

```yaml
# Kraft current state info metric rule
- pattern: "kafka.server<type=raft-metrics><>current-state: ([a-z]+)"
  name: kafka_server_raft_metrics_current_state_info
  type: GAUGE
  value: 1
  labels:
    "state": "$1"
# Kraft specific rules for raft-metrics, raft-channel-metrics, broker-metadata-metrics
- pattern: kafka.server<type=(.+)><>([a-z-]+)-total
  name: kafka_server_$1_$2_total
  type: COUNTER
- pattern: kafka.server<type=(.+)><>([a-z-]+)
  name: kafka_server_$1_$2
  type: GAUGE
```

And we also get these:

```
# HELP kafka_server_raft_metrics_current_state_info The current state of this member; possible values are leader, candidate, voted, follower, unattached, observer kafka.server:name=null,type=raft-metrics,attribute=current-state
# TYPE kafka_server_raft_metrics_current_state_info gauge
kafka_server_raft_metrics_current_state_info{state="follower",} 1.0
# HELP kafka_server_raft_metrics_log_end_epoch The current raft log end epoch. kafka.server:name=null,type=raft-metrics,attribute=log-end-epoch
# TYPE kafka_server_raft_metrics_log_end_epoch gauge
kafka_server_raft_metrics_log_end_epoch 134.0
...
# HELP kafka_server_raft_channel_metrics_request_total The total number of requests sent kafka.server:name=null,type=raft-channel-metrics,attribute=request-total
# TYPE kafka_server_raft_channel_metrics_request_total counter
kafka_server_raft_channel_metrics_request_total 693158.0
# HELP kafka_server_raft_channel_metrics_response_total The total number of responses received kafka.server:name=null,type=raft-channel-metrics,attribute=response-total
# TYPE kafka_server_raft_channel_metrics_response_total counter
kafka_server_raft_channel_metrics_response_total 693148.0
...
```