### PR TITLE
Support for HTTPServer's SampleNameFilter

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.prometheus.jmx</groupId>
+        <groupId>io.acryl.prometheus.jmx</groupId>
         <artifactId>parent</artifactId>
-        <version>0.20.1-SNAPSHOT</version>
+        <version>0.20.1</version>
     </parent>
 
     <artifactId>collector</artifactId>

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/sampleNameFilter/SampleNameFilterConfigurationTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/sampleNameFilter/SampleNameFilterConfigurationTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2024 The Prometheus jmx_exporter Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prometheus.jmx.test.http.sampleNameFilter;
+
+import static io.prometheus.jmx.test.support.MetricsAssertions.assertThatMetricIn;
+import static io.prometheus.jmx.test.support.RequestResponseAssertions.assertThatResponseForRequest;
+
+import io.prometheus.jmx.test.BaseTest;
+import io.prometheus.jmx.test.Metric;
+import io.prometheus.jmx.test.MetricsParser;
+import io.prometheus.jmx.test.Mode;
+import io.prometheus.jmx.test.support.ContentConsumer;
+import io.prometheus.jmx.test.support.HealthyRequest;
+import io.prometheus.jmx.test.support.HealthyResponse;
+import io.prometheus.jmx.test.support.MetricsRequest;
+import io.prometheus.jmx.test.support.MetricsResponse;
+import io.prometheus.jmx.test.support.OpenMetricsRequest;
+import io.prometheus.jmx.test.support.OpenMetricsResponse;
+import io.prometheus.jmx.test.support.PrometheusMetricsRequest;
+import io.prometheus.jmx.test.support.PrometheusMetricsResponse;
+import java.util.Collection;
+import org.antublue.test.engine.api.TestEngine;
+
+public class SampleNameFilterConfigurationTest extends BaseTest implements ContentConsumer {
+
+    @TestEngine.Test
+    public void testHealthy() throws InterruptedException {
+        assertThatResponseForRequest(new HealthyRequest(testState.httpClient()))
+                .isSuperset(HealthyResponse.RESULT_200);
+    }
+
+    @TestEngine.Test
+    public void testMetrics() {
+        assertThatResponseForRequest(new MetricsRequest(testState.httpClient()))
+                .isSuperset(MetricsResponse.RESULT_200)
+                .dispatch(this);
+    }
+
+    @TestEngine.Test
+    public void testMetricsOpenMetricsFormat() {
+        assertThatResponseForRequest(new OpenMetricsRequest(testState.httpClient()))
+                .isSuperset(OpenMetricsResponse.RESULT_200)
+                .dispatch(this);
+    }
+
+    @TestEngine.Test
+    public void testMetricsPrometheusFormat() {
+        assertThatResponseForRequest(new PrometheusMetricsRequest(testState.httpClient()))
+                .isSuperset(PrometheusMetricsResponse.RESULT_200)
+                .dispatch(this);
+    }
+
+    @Override
+    public void accept(String content) {
+        Collection<Metric> metrics = MetricsParser.parse(content);
+
+        String buildInfoName =
+                testArgument.mode() == Mode.JavaAgent
+                        ? "jmx_prometheus_javaagent"
+                        : "jmx_prometheus_httpserver";
+
+        assertThatMetricIn(metrics)
+                .withName("jmx_exporter_build_info")
+                .withLabel("name", buildInfoName)
+                .exists();
+
+        assertThatMetricIn(metrics)
+                .withName("java_lang_Memory_NonHeapMemoryUsage_committed")
+                .exists();
+
+        assertThatMetricIn(metrics)
+                .withName("io_prometheus_jmx_tabularData_Server_1_Disk_Usage_Table_size")
+                .withLabel("source", "/dev/sda1")
+                .withValue(7.516192768E9)
+                .exists();
+
+        assertThatMetricIn(metrics)
+                .withName("io_prometheus_jmx_tabularData_Server_2_Disk_Usage_Table_pcent")
+                .withLabel("source", "/dev/sda2")
+                .withValue(0.8)
+                .exists();
+
+        assertThatMetricIn(metrics).withName("jvm_threads_state").doesNotExist();
+    }
+}

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/sampleNameFilter/SampleNameFilterConfigurationTest/JavaAgent/application.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/sampleNameFilter/SampleNameFilterConfigurationTest/JavaAgent/application.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+java \
+  -Xmx128M \
+  -javaagent:jmx_prometheus_javaagent.jar=8888:exporter.yaml \
+  -jar jmx_example_application.jar

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/sampleNameFilter/SampleNameFilterConfigurationTest/JavaAgent/exporter.yaml
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/sampleNameFilter/SampleNameFilterConfigurationTest/JavaAgent/exporter.yaml
@@ -1,0 +1,6 @@
+httpServer:
+  sampleNameFilter:
+    name-must-not-be-equal-to:
+      - jvm_threads_state
+rules:
+  - pattern: ".*"

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/sampleNameFilter/SampleNameFilterConfigurationTest/Standalone/application.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/sampleNameFilter/SampleNameFilterConfigurationTest/Standalone/application.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+java \
+  -Xmx128M \
+  -Dcom.sun.management.jmxremote=true \
+  -Dcom.sun.management.jmxremote.authenticate=false \
+  -Dcom.sun.management.jmxremote.local.only=false \
+  -Dcom.sun.management.jmxremote.port=9999 \
+  -Dcom.sun.management.jmxremote.registry.ssl=false \
+  -Dcom.sun.management.jmxremote.rmi.port=9999 \
+  -Dcom.sun.management.jmxremote.ssl.need.client.auth=false \
+  -Dcom.sun.management.jmxremote.ssl=false \
+  -jar jmx_example_application.jar

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/sampleNameFilter/SampleNameFilterConfigurationTest/Standalone/exporter.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/sampleNameFilter/SampleNameFilterConfigurationTest/Standalone/exporter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+java \
+  -Xmx128M \
+  -jar jmx_prometheus_httpserver.jar 8888 exporter.yaml

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/sampleNameFilter/SampleNameFilterConfigurationTest/Standalone/exporter.yaml
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/sampleNameFilter/SampleNameFilterConfigurationTest/Standalone/exporter.yaml
@@ -1,0 +1,7 @@
+httpServer:
+  sampleNameFilter:
+    name-must-not-be-equal-to:
+      - jvm_threads_state
+hostPort: application:9999
+rules:
+  - pattern: ".*"

--- a/jmx_prometheus_common/pom.xml
+++ b/jmx_prometheus_common/pom.xml
@@ -3,12 +3,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.prometheus.jmx</groupId>
+        <groupId>io.acryl.prometheus.jmx</groupId>
         <artifactId>parent</artifactId>
-        <version>0.20.1-SNAPSHOT</version>
+        <version>0.20.1</version>
     </parent>
 
-    <groupId>io.prometheus.jmx</groupId>
+    <groupId>io.acryl.prometheus.jmx</groupId>
     <artifactId>jmx_prometheus_common</artifactId>
     <name>Prometheus JMX Exporter - Common</name>
     <description>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>io.prometheus.jmx</groupId>
             <artifactId>collector</artifactId>
-            <version>${project.version}</version>
+            <version>0.20.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ConvertToStringList.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ConvertToStringList.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 The Prometheus jmx_exporter Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prometheus.jmx.common.configuration;
+
+import io.prometheus.jmx.common.util.Precondition;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class ConvertToStringList implements Function<Object, List<String>> {
+
+    private final Supplier<? extends RuntimeException> supplier;
+
+    /**
+     * Constructor
+     *
+     * @param supplier supplier
+     */
+    public ConvertToStringList(Supplier<? extends RuntimeException> supplier) {
+        Precondition.notNull(supplier);
+        this.supplier = supplier;
+    }
+
+    /**
+     * Method to apply a function
+     *
+     * @param value value
+     * @return the return value
+     */
+    @Override
+    public List<String> apply(Object value) {
+        if (value == null) {
+            throw new IllegalArgumentException();
+        }
+
+        try {
+            return (List<String>) value;
+        } catch (Throwable t) {
+            throw supplier.get();
+        }
+    }
+}

--- a/jmx_prometheus_httpserver/pom.xml
+++ b/jmx_prometheus_httpserver/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.prometheus.jmx</groupId>
+        <groupId>io.acryl.prometheus.jmx</groupId>
         <artifactId>parent</artifactId>
-        <version>0.20.1-SNAPSHOT</version>
+        <version>0.20.1</version>
     </parent>
 
     <artifactId>jmx_prometheus_httpserver</artifactId>

--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.prometheus.jmx</groupId>
+        <groupId>io.acryl.prometheus.jmx</groupId>
         <artifactId>parent</artifactId>
-        <version>0.20.1-SNAPSHOT</version>
+        <version>0.20.1</version>
     </parent>
 
     <artifactId>jmx_prometheus_javaagent</artifactId>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>io.prometheus.jmx</groupId>
             <artifactId>collector</artifactId>
-            <version>${project.version}</version>
+            <version>0.20.0</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.prometheus.jmx</groupId>
+    <groupId>io.acryl.prometheus.jmx</groupId>
     <artifactId>parent</artifactId>
-    <version>0.20.1-SNAPSHOT</version>
+    <version>0.20.1</version>
 
     <name>Prometheus JMX Exporter</name>
     <description>
@@ -55,12 +55,12 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>acryl-nexus</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>acryl-nexus</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
Allows excluding problematic metrics (e.g. `jvm_threads_*` on a process with thousands of threads) when using the agent. 