### PR TITLE
Cache MBean Domain for performance

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -213,6 +213,7 @@ class JmxScraper {
         }
 
         final String mBeanNameString = mBeanName.toString();
+        final String mBeanDomain = mBeanName.getDomain();
 
         for (Object object : attributes) {
             // The contents of an AttributeList should all be Attribute instances, but we'll verify
@@ -238,7 +239,7 @@ class JmxScraper {
                 LOGGER.log(FINE, "%s_%s process", mBeanName, mBeanAttributeInfo.getName());
                 processBeanValue(
                         mBeanName,
-                        mBeanName.getDomain(),
+                        mBeanDomain,
                         jmxMBeanPropertyCache.getKeyPropertyList(mBeanName),
                         new LinkedList<>(),
                         mBeanAttributeInfo.getName(),


### PR DESCRIPTION
As with #917, we also call `ObjectName#getDomain()` once
per-_attribute_, which is unnecessary and can be expensive when MBeans
contain a large number of attributes.

This is because `ObjectName#getDomain()` allocates a new String, copying
the domain into it.

Signed-off-by: Nick Telford <nick.telford@gmail.com>
