### PR TITLE
Added hazelcast example config

### DIFF
--- a/example_configs/hazelcast.yml
+++ b/example_configs/hazelcast.yml
@@ -1,0 +1,23 @@
+#---
+attrNameSnakeCase: true
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+whitelistObjectNames:
+  - "com.hazelcast:type=Metrics,*"
+
+rules:
+  - pattern: "^com.hazelcast<type=Metrics, instance=(.*), prefix=(.*), tag([0-9]+)=(.*)><>(.+):"
+    name: hazelcast_$5
+    attrNameSnakeCase: true
+    labels:
+      instance: $1
+      prefix: $2
+      tag$3: $4
+
+  - pattern: "^com.hazelcast<type=Metrics, instance=(.*), prefix=(.*)><>(.+):"
+    name: hazelcast_$3
+    attrNameSnakeCase: true
+    labels:
+      instance: $1
+      prefix: $2
+


### PR DESCRIPTION
Added example config to fetch custom hazelcast metrics from jmx means.

The metrics will be like as following

hazelcast_total_max_get_latency{instance="hz-instance",prefix="map",tag0="\"name=request-trace-cache\"",} 1.0
hazelcast_priority_queue_size{instance="hz-auth-instance",prefix="operation",} 0.0

It can also handle metrics with multiple tags.

hazelcast_connection_type{instance="hazelcastCacheInstance",prefix="tcp.connection, tag0=\"endpoint=[localhost]:5703\"",tag1="\"bindAddress=[testserver]:5703\"",} 1.0
