### PR TITLE
Fix jmx ssl not work issue

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -120,7 +120,9 @@ class JmxScraper {
                 environment.put(
                         RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE,
                         clientSocketFactory);
-                environment.put("com.sun.jndi.rmi.factory.socket", clientSocketFactory);
+                // https://db.apache.org/derby/docs/10.10/adminguide/radminjmxenablepwdssl.html
+                // this is use a java se 5 jdk, when use java se 17 jdk, will not work. 
+                // environment.put("com.sun.jndi.rmi.factory.socket", clientSocketFactory);
             }
 
             jmxc = JMXConnectorFactory.connect(new JMXServiceURL(jmxUrl), environment);


### PR DESCRIPTION
`config.yaml`

```yaml
startDelaySeconds: 0
username: admin
password: password
jmxUrl: "service:jmx:rmi:///jndi/rmi://127.0.0.1:1234/jmxrmi"
ssl: true
lowercaseOutputName: false
lowercaseOutputLabelNames: false
```
`start jmx_prometheus_httpserver`

```shell
java -Djavax.net.ssl.trustStore=jmx.p12 \
-Djavax.net.ssl.trustStorePassword=changeit \
-XshowSettings:vm -jar jmx_prometheus_httpserver-0.20.0.jar 49101 ./config.yaml
```
```java
Caused by: javax.naming.CommunicationException [Root exception is java.rmi.ConnectIOException: error during JRMP connection establishment; nested exception is:
        javax.net.ssl.SSLHandshakeException: Remote host terminated the handshake]
        at jdk.naming.rmi/com.sun.jndi.rmi.registry.RegistryContext.lookup(RegistryContext.java:138)
        at java.naming/com.sun.jndi.toolkit.url.GenericURLContext.lookup(GenericURLContext.java:220)
        at java.naming/javax.naming.InitialContext.lookup(InitialContext.java:409)
        at java.management.rmi/javax.management.remote.rmi.RMIConnector.findRMIServerJNDI(RMIConnector.java:1839)
        at java.management.rmi/javax.management.remote.rmi.RMIConnector.findRMIServer(RMIConnector.java:1813)
        at java.management.rmi/javax.management.remote.rmi.RMIConnector.connect(RMIConnector.java:302)
        ... 19 more
Caused by: java.rmi.ConnectIOException: error during JRMP connection establishment; nested exception is:
        javax.net.ssl.SSLHandshakeException: Remote host terminated the handshake
        at java.rmi/sun.rmi.transport.tcp.TCPChannel.createConnection(TCPChannel.java:308)
        at java.rmi/sun.rmi.transport.tcp.TCPChannel.newConnection(TCPChannel.java:204)
        at java.rmi/sun.rmi.server.UnicastRef.newCall(UnicastRef.java:344)
        at java.rmi/sun.rmi.registry.RegistryImpl_Stub.lookup(RegistryImpl_Stub.java:116)
        at jdk.naming.rmi/com.sun.jndi.rmi.registry.RegistryContext.lookup(RegistryContext.java:134)
        ... 24 more
Caused by: javax.net.ssl.SSLHandshakeException: Remote host terminated the handshake
        at java.base/sun.security.ssl.SSLSocketImpl.handleEOF(SSLSocketImpl.java:1715)
        at java.base/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1514)
        at java.base/sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1421)
        at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:455)
        at java.base/sun.security.ssl.SSLSocketImpl.ensureNegotiated(SSLSocketImpl.java:921)
        at java.base/sun.security.ssl.SSLSocketImpl$AppOutputStream.write(SSLSocketImpl.java:1291)
        at java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:81)
        at java.base/java.io.BufferedOutputStream.flush(BufferedOutputStream.java:142)
        at java.base/java.io.DataOutputStream.flush(DataOutputStream.java:128)
        at java.rmi/sun.rmi.transport.tcp.TCPChannel.createConnection(TCPChannel.java:230)
        ... 28 more
Caused by: java.io.EOFException: SSL peer shut down incorrectly
        at java.base/sun.security.ssl.SSLSocketInputRecord.read(SSLSocketInputRecord.java:489)
        at java.base/sun.security.ssl.SSLSocketInputRecord.readHeader(SSLSocketInputRecord.java:478)
        at java.base/sun.security.ssl.SSLSocketInputRecord.decode(SSLSocketInputRecord.java:160)
        at java.base/sun.security.ssl.SSLTransport.decode(SSLTransport.java:111)
        at java.base/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1506)
        ... 36 more
```
