### PR TITLE
Added code to deduplicate metrics

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -441,13 +441,13 @@ public class JmxCollector implements MultiCollector {
     static class Receiver implements JmxScraper.MBeanReceiver {
 
         Map<String, UnknownSnapshot.Builder> unknownSnapshotBuilderMap = new HashMap<>();
-        Map<String, List<DataPoint>> unknownSnapshotDatapointMap = new HashMap<>();
+        Map<String, List<DataPoint>> unknownDataPointMap = new HashMap<>();
 
         Map<String, CounterSnapshot.Builder> counterSnapshotBuilderMap = new HashMap<>();
-        Map<String, List<DataPoint>> counterSnapshotDatapointMap = new HashMap<>();
+        Map<String, List<DataPoint>> counterDataPointMap = new HashMap<>();
 
         Map<String, GaugeSnapshot.Builder> gaugeSnapshotBuilderMap = new HashMap<>();
-        Map<String, List<DataPoint>> gaugSnapshotDatapointMap = new HashMap<>();
+        Map<String, List<DataPoint>> gaugDataPointMap = new HashMap<>();
 
         Config config;
         MatchedRulesCache.StalenessTracker stalenessTracker;
@@ -738,7 +738,7 @@ public class JmxCollector implements MultiCollector {
                                                 .help(finalMatchedRule.help));
 
                         List<DataPoint> dataPoints =
-                                counterSnapshotDatapointMap.computeIfAbsent(
+                                counterDataPointMap.computeIfAbsent(
                                         sanitizedName, name -> new ArrayList<>());
 
                         dataPoints.add(
@@ -760,7 +760,7 @@ public class JmxCollector implements MultiCollector {
                                                 .help(finalMatchedRule.help));
 
                         List<DataPoint> dataPoints =
-                                gaugSnapshotDatapointMap.computeIfAbsent(
+                                gaugDataPointMap.computeIfAbsent(
                                         sanitizedName, name -> new ArrayList<>());
 
                         dataPoints.add(
@@ -784,7 +784,7 @@ public class JmxCollector implements MultiCollector {
                                                 .help(finalMatchedRule.help));
 
                         List<DataPoint> dataPoints =
-                                unknownSnapshotDatapointMap.computeIfAbsent(
+                                unknownDataPointMap.computeIfAbsent(
                                         sanitizedName, name -> new ArrayList<>());
 
                         dataPoints.add(
@@ -858,7 +858,7 @@ public class JmxCollector implements MultiCollector {
             long counter = 0;
             Set<Labels> labels = new HashSet<>();
 
-            for (DataPoint dataPoint : receiver.counterSnapshotDatapointMap.get(key)) {
+            for (DataPoint dataPoint : receiver.counterDataPointMap.get(key)) {
                 if (labels.contains(dataPoint.labels)) {
                     dataPoint.labels = Labels.of("_" + counter + "_", "id").merge(dataPoint.labels);
                     counter++;
@@ -885,7 +885,7 @@ public class JmxCollector implements MultiCollector {
             long counter = 0;
             Set<Labels> labels = new HashSet<>();
 
-            for (DataPoint dataPoint : receiver.gaugSnapshotDatapointMap.get(key)) {
+            for (DataPoint dataPoint : receiver.gaugDataPointMap.get(key)) {
                 if (labels.contains(dataPoint.labels)) {
                     dataPoint.labels = Labels.of("_" + counter + "_", "id").merge(dataPoint.labels);
                     counter++;
@@ -913,7 +913,7 @@ public class JmxCollector implements MultiCollector {
             long counter = 0;
             Set<Labels> labels = new HashSet<>();
 
-            for (DataPoint dataPoint : receiver.unknownSnapshotDatapointMap.get(key)) {
+            for (DataPoint dataPoint : receiver.unknownDataPointMap.get(key)) {
                 if (labels.contains(dataPoint.labels)) {
                     dataPoint.labels = Labels.of("_" + counter + "_", "id").merge(dataPoint.labels);
                     counter++;

--- a/collector/src/main/java/io/prometheus/jmx/Murmur3Hash.java
+++ b/collector/src/main/java/io/prometheus/jmx/Murmur3Hash.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2020-2023 The Prometheus jmx_exporter Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prometheus.jmx;
+
+import java.nio.charset.StandardCharsets;
+
+/** Class to implement a Murmur3Hash */
+public class Murmur3Hash {
+
+    private static final int SEED = 0;
+
+    /** Constructor */
+    private Murmur3Hash() {
+        // DO NOTHING
+    }
+
+    /**
+     * Method to hash a String to a Murmur3 hash String
+     *
+     * @param string string
+     * @return a Murmur3 hash String
+     */
+    public static String hash(String string) {
+        if (string == null) {
+            return null;
+        }
+        byte[] data = string.getBytes(StandardCharsets.UTF_8);
+        int hashValue = hashBytes(data);
+        return Integer.toHexString(hashValue);
+    }
+
+    private static int hashBytes(byte[] bytes) {
+        int length = bytes.length;
+        int h = SEED;
+        int currentIndex = 0;
+
+        if (length > 0) {
+            int nBlocks = length / 4;
+
+            for (int i = 0; i < nBlocks; i++) {
+                int k = bytes[currentIndex++] & 0xFF;
+                k |= (bytes[currentIndex++] & 0xFF) << 8;
+                k |= (bytes[currentIndex++] & 0xFF) << 16;
+                k |= (bytes[currentIndex++] & 0xFF) << 24;
+
+                k *= 0xcc9e2d51;
+                k = Integer.rotateLeft(k, 15);
+                k *= 0x1b873593;
+
+                h ^= k;
+                h = Integer.rotateLeft(h, 13);
+                h = h * 5 + 0xe6546b64;
+            }
+
+            int k1 = 0;
+            switch (length & 3) {
+                case 3:
+                    k1 ^= (bytes[currentIndex + 2] & 0xFF) << 16;
+                case 2:
+                    k1 ^= (bytes[currentIndex + 1] & 0xFF) << 8;
+                case 1:
+                    k1 ^= (bytes[currentIndex] & 0xFF);
+                    k1 *= 0xcc9e2d51;
+                    k1 = Integer.rotateLeft(k1, 15);
+                    k1 *= 0x1b873593;
+                    h ^= k1;
+            }
+
+            h ^= length;
+            h ^= h >>> 16;
+            h *= 0x85ebca6b;
+            h ^= h >>> 13;
+            h *= 0xc2b2ae35;
+            h ^= h >>> 16;
+        }
+
+        return h;
+    }
+}

--- a/collector/src/test/java/io/prometheus/jmx/CollidingNameMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/CollidingNameMBean.java
@@ -1,0 +1,40 @@
+package io.prometheus.jmx;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+public interface CollidingNameMBean {
+
+    int getValue();
+}
+
+class CollidingName implements CollidingNameMBean {
+
+    private final int value;
+
+    public CollidingName(int value) {
+        this.value = value;
+    }
+
+    @Override
+    public int getValue() {
+        return 345;
+    }
+
+    static void registerBeans(MBeanServer mbs) {
+        // Loop through the entire ASCII character set
+        for (int i = 0; i < 127; i++) {
+            try {
+                // Create and try to register an MBean with the name
+                ObjectName objectName =
+                        new ObjectName(
+                                "io.prometheus.jmx.test:type=Colliding" + ((char) i) + "Name");
+                CollidingName collidingName = new CollidingName(i);
+                mbs.registerMBean(collidingName, objectName);
+            } catch (Throwable t) {
+                // Ignore since we are testing all ASCII characters, which may not be allowed in an
+                // ObjectName
+            }
+        }
+    }
+}

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -37,6 +37,8 @@ public class JmxCollectorTest {
         TomcatServlet.registerBean(mbs);
         Bool.registerBean(mbs);
         Camel.registerBean(mbs);
+        TotalValue.registerBean(mbs);
+        CollidingName.registerBeans(mbs);
     }
 
     @Before

--- a/collector/src/test/java/io/prometheus/jmx/PrometheusRegistryUtils.java
+++ b/collector/src/test/java/io/prometheus/jmx/PrometheusRegistryUtils.java
@@ -23,7 +23,9 @@ import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.UnknownSnapshot;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -72,10 +74,10 @@ public class PrometheusRegistryUtils {
                                         .filter(
                                                 (Predicate<DataPointSnapshot>)
                                                         dataPointSnapshot ->
-                                                                dataPointSnapshot
-                                                                                .getLabels()
-                                                                                .compareTo(labels)
-                                                                        == 0)
+                                                                isSubsetOfLabels(
+                                                                        dataPointSnapshot
+                                                                                .getLabels(),
+                                                                        labels))
                                         .findFirst()
                                         .ifPresent(
                                                 (Consumer<DataPointSnapshot>)
@@ -105,5 +107,15 @@ public class PrometheusRegistryUtils {
         // TODO add other DataPoint types
 
         return value;
+    }
+
+    private static boolean isSubsetOfLabels(Labels set, Labels subSet) {
+        final Set<String> labelSet = new HashSet<>();
+        set.forEach(label -> labelSet.add(label.getName() + "\\\"->\\\"" + label.getValue()));
+
+        final Set<String> labelSubSet = new HashSet<>();
+        subSet.forEach(label -> labelSubSet.add(label.getName() + "\\\"->\\\"" + label.getValue()));
+
+        return labelSet.containsAll(labelSubSet);
     }
 }

--- a/collector/src/test/java/io/prometheus/jmx/TotalValueMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/TotalValueMBean.java
@@ -1,0 +1,31 @@
+package io.prometheus.jmx;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+public interface TotalValueMBean {
+
+    int getTotal();
+}
+
+class TotalValue implements TotalValueMBean {
+
+    public TotalValue() {
+        // DO NOTHING
+    }
+
+    @Override
+    public int getTotal() {
+        return 345;
+    }
+
+    static void registerBean(MBeanServer mbs) throws javax.management.JMException {
+        ObjectName mxbeanName = new ObjectName("io.prometheus.jmx.test:type=Total-Value");
+        TotalValue mxbean = new TotalValue();
+        mbs.registerMBean(mxbean, mxbeanName);
+
+        mxbeanName = new ObjectName("io.prometheus.jmx.test:type=Total.Value");
+        mxbean = new TotalValue();
+        mbs.registerMBean(mxbean, mxbeanName);
+    }
+}


### PR DESCRIPTION
Added code to deduplicate metrics.

The `CounterSnapshot.builder()`, `GaugeSnapShot.builder()`, and `UnknownSnapshot.builder()` have no way to get the set of `DatapointSnapshot` list, I had to track the raw metric data (`Label` and value) in lists.

At the end of the collection object, before creating the `MetricsSnapshot` object, the code tracks the `Labels` that have been seen using a set. If the `Labels` exists in the set, a new label pair ( key = `_` + counter + `_`, value = `"id"` is added to make the metric unique. (Reverse mapping to prevent potential metric label name collision)