### PR TITLE
Enhanced ExcludeObjectNameAttributesTest

### DIFF
--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/ExcludeObjectNameAttributesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/ExcludeObjectNameAttributesTest.java
@@ -74,18 +74,36 @@ public class ExcludeObjectNameAttributesTest extends AbstractTest
         excludeAttributeNameSet.add("_ClassPath");
         excludeAttributeNameSet.add("_SystemProperties");
 
+        Set<String> excludeJavaLangMemoryAttributeSet = new HashSet<>();
+        excludeJavaLangMemoryAttributeSet.add("NonHeapMemoryUsage");
+        excludeJavaLangMemoryAttributeSet.add("Verbose");
+        excludeJavaLangMemoryAttributeSet.add("ObjectPendingFinalizationCount");
+
         /*
          * Assert that we don't have any metrics that start with ...
          *
          * name = java_lang*
+         * attribute = _ClassPath
+         * attribute = __SystemProperties
+         *
+         * ... or...
+         *
+         * name = java_lang_Memory
+         * attribute = _Verbose
          */
         metrics.forEach(
                 metric -> {
                     String name = metric.name();
-                    if (name.contains("java_lang")) {
+                    if (name.equals("java_lang_Memory")) {
+                        for (String attributeName : excludeJavaLangMemoryAttributeSet) {
+                            if (name.equals(attributeName)) {
+                                fail("metric [" + metric + "] found");
+                            }
+                        }
+                    } else {
                         for (String attributeName : excludeAttributeNameSet) {
                             if (name.contains(attributeName)) {
-                                fail("metric found");
+                                fail("metric [" + metric + "] found");
                             }
                         }
                     }

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/ExcludeObjectNameAttributesTest/JavaAgent/exporter.yaml
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/ExcludeObjectNameAttributesTest/JavaAgent/exporter.yaml
@@ -40,6 +40,9 @@ excludeObjectNameAttributes:
     - "ObjectName"
   "java.lang:type=Memory":
     - "ObjectName"
+    - "NonHeapMemoryUsage"
+    - "Verbose"
+    - "ObjectPendingFinalizationCount"
   "java.lang:name=CodeHeap 'non-profiled nmethods',type=MemoryPool":
     - "ObjectName"
   "com.sun.management:type=HotSpotDiagnostic":

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/ExcludeObjectNameAttributesTest/Standalone/exporter.yaml
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/ExcludeObjectNameAttributesTest/Standalone/exporter.yaml
@@ -41,6 +41,9 @@ excludeObjectNameAttributes:
     - "ObjectName"
   "java.lang:type=Memory":
     - "ObjectName"
+    - "NonHeapMemoryUsage"
+    - "Verbose"
+    - "ObjectPendingFinalizationCount"
   "java.lang:name=CodeHeap 'non-profiled nmethods',type=MemoryPool":
     - "ObjectName"
   "com.sun.management:type=HotSpotDiagnostic":


### PR DESCRIPTION
Enhanced ExcludeObjectNameAttributesTest to include an example of excluding `java_lang_Memory` attributes `NonHeapMemoryUsage`, `Verbose`, and `ObjectPendingFinalizationCount`. 