### PR TITLE
Fixed integration tests

### DIFF
--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/MinimalTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/MinimalTest.java
@@ -66,7 +66,7 @@ public class MinimalTest extends AbstractExporterTest
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/OptionalValueMBeanTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/OptionalValueMBeanTest.java
@@ -44,7 +44,7 @@ public class OptionalValueMBeanTest extends AbstractExporterTest
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/CompleteHttpServerConfigurationTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/CompleteHttpServerConfigurationTest.java
@@ -222,7 +222,7 @@ public class CompleteHttpServerConfigurationTest extends AbstractExporterTest
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationPBKDF2WithHmacSHA1Test.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationPBKDF2WithHmacSHA1Test.java
@@ -57,7 +57,7 @@ public class BasicAuthenticationPBKDF2WithHmacSHA1Test extends AbstractBasicAuth
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationPBKDF2WithHmacSHA256Test.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationPBKDF2WithHmacSHA256Test.java
@@ -57,7 +57,7 @@ public class BasicAuthenticationPBKDF2WithHmacSHA256Test extends AbstractBasicAu
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationPBKDF2WithHmacSHA512Test.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationPBKDF2WithHmacSHA512Test.java
@@ -57,7 +57,7 @@ public class BasicAuthenticationPBKDF2WithHmacSHA512Test extends AbstractBasicAu
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationPlaintextTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationPlaintextTest.java
@@ -43,7 +43,7 @@ public class BasicAuthenticationPlaintextTest extends AbstractBasicAuthenticatio
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationSHA1Test.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationSHA1Test.java
@@ -43,7 +43,7 @@ public class BasicAuthenticationSHA1Test extends AbstractBasicAuthenticationTest
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationSHA256Test.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationSHA256Test.java
@@ -43,7 +43,7 @@ public class BasicAuthenticationSHA256Test extends AbstractBasicAuthenticationTe
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationSHA512Test.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationSHA512Test.java
@@ -43,7 +43,7 @@ public class BasicAuthenticationSHA512Test extends AbstractBasicAuthenticationTe
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLAndBasicAuthenticationPBKDF2WithHmacSHA512Test.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLAndBasicAuthenticationPBKDF2WithHmacSHA512Test.java
@@ -65,7 +65,7 @@ public class SSLAndBasicAuthenticationPBKDF2WithHmacSHA512Test
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithJKSKeyStoreMultipleCertificatesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithJKSKeyStoreMultipleCertificatesTest.java
@@ -63,7 +63,7 @@ public class SSLWithJKSKeyStoreMultipleCertificatesTest extends AbstractSSLTest
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithJKSKeyStoreTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithJKSKeyStoreTest.java
@@ -63,7 +63,7 @@ public class SSLWithJKSKeyStoreTest extends AbstractSSLTest
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithJKSKeyStoreTest2.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithJKSKeyStoreTest2.java
@@ -63,7 +63,7 @@ public class SSLWithJKSKeyStoreTest2 extends AbstractSSLTest
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithPKCS12KeyStoreMultipleCertificatesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithPKCS12KeyStoreMultipleCertificatesTest.java
@@ -59,7 +59,7 @@ public class SSLWithPKCS12KeyStoreMultipleCertificatesTest extends AbstractSSLTe
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithPKCS12KeyStoreTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithPKCS12KeyStoreTest.java
@@ -59,7 +59,7 @@ public class SSLWithPKCS12KeyStoreTest extends AbstractSSLTest
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithPKCS12KeyStoreTest2.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithPKCS12KeyStoreTest2.java
@@ -59,7 +59,7 @@ public class SSLWithPKCS12KeyStoreTest2 extends AbstractSSLTest
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/threads/ThreadsConfigurationTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/threads/ThreadsConfigurationTest.java
@@ -44,7 +44,7 @@ public class ThreadsConfigurationTest extends AbstractExporterTest
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/rmi/ssl/MinimalRMISSLTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/rmi/ssl/MinimalRMISSLTest.java
@@ -73,7 +73,7 @@ public class MinimalRMISSLTest extends AbstractExporterTest
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/rmi/ssl/RMIRegistrySSLDisabledTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/rmi/ssl/RMIRegistrySSLDisabledTest.java
@@ -73,7 +73,7 @@ public class RMIRegistrySSLDisabledTest extends AbstractExporterTest
         String buildInfoName =
                 isJmxExporterModeJavaAgent
                         ? "jmx_prometheus_javaagent"
-                        : "jmx_prometheus_standalone";
+                        : "jmx_prometheus_httpserver";
 
         assertMetric(metrics)
                 .ofType(Metric.Type.GAUGE)


### PR DESCRIPTION
Fixed integration tests.

Specifically, changed this code to match the current standalone build info name.

```java
String buildInfoName =
    isJmxExporterModeJavaAgent
        ? "jmx_prometheus_javaagent"
         : "jmx_prometheus_httpserver";
```