### PR TITLE
Updated CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ machine: true
 jobs:
   build:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2204:current
     working_directory: ~/circleci-java
     steps:
       - run:


### PR DESCRIPTION
Updated CircleCI image. The previous image has been deprecated.

https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177