### PR TITLE
Updates prometheus java_client to 1.3.2

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -55,17 +55,17 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>prometheus-metrics-core</artifactId>
-            <version>1.3.1</version>
+            <version>${prometheus.metrics.version}</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>prometheus-metrics-model</artifactId>
-            <version>1.3.1</version>
+            <version>${prometheus.metrics.version}</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>prometheus-metrics-exposition-formats</artifactId>
-            <version>1.3.1</version>
+            <version>${prometheus.metrics.version}</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>

--- a/integration_test_suite/jmx_example_application/pom.xml
+++ b/integration_test_suite/jmx_example_application/pom.xml
@@ -33,13 +33,13 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>prometheus-metrics-core</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>prometheus-metrics-exposition-formats</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.2</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <prometheus.metrics.version>1.3.1</prometheus.metrics.version>
+        <prometheus.metrics.version>1.3.2</prometheus.metrics.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
This is mainly to fix a performance regression that got introduced in JMX Exporter 1.0.0 with the switch to the new Prometheus Java Client.

We traced it down to a problem that others have found (and fixed) before us:
- https://github.com/prometheus/client_java/pull/963
- https://github.com/prometheus/client_java/pull/985

Both of these are fixed in java_client 1.3.2 and performance is back to normal.

For comparison. Assembling metrics took less than 500ms on 0.20 but took over a minute on 1.0.1


btw. the CONTRIBUTING file says to open PRs against `development` but no such branch exists and the `next-release` branch hasn't been updated in three years so I guess `main` is correct and `CONTRIBUTING.md` is wrong? If so, I'm happy to update it.
It also says to address the maintainers using "@".... but that just feels so wrong so I'll just ping one of you @dhoard 