### PR TITLE
Support for extra metrics

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -64,6 +64,12 @@ public class JmxCollector implements MultiCollector {
 
     private final Mode mode;
 
+    static class ExtraMetric {
+        String name;
+        Object value;
+        String description;
+    }
+
     static class Rule {
         Pattern pattern;
         String name;
@@ -80,6 +86,7 @@ public class JmxCollector implements MultiCollector {
     public static class MetricCustomizer {
         MBeanFilter mbeanFilter;
         List<String> attributesAsLabels;
+        List<ExtraMetric> extraMetrics;
     }
 
     public static class MBeanFilter {
@@ -351,9 +358,23 @@ public class JmxCollector implements MultiCollector {
                 if (attributesAsLabels == null) {
                     attributesAsLabels = new ArrayList<>();
                 }
+                List<Map<String, Object>> extraMetricsYaml =
+                        (List<Map<String, Object>>) metricCustomizerYaml.get("extraMetrics");
+                if (extraMetricsYaml == null) {
+                    extraMetricsYaml = new ArrayList<>();
+                }
+                List<ExtraMetric> extraMetrics = new ArrayList<>();
+                for (Map<String, Object> extraMetricYaml : extraMetricsYaml) {
+                    ExtraMetric extraMetric = new ExtraMetric();
+                    extraMetric.name = (String) extraMetricYaml.get("name");
+                    extraMetric.value = extraMetricYaml.get("value");
+                    extraMetric.description = (String) extraMetricYaml.get("description");
+                    extraMetrics.add(extraMetric);
+                }
 
                 MetricCustomizer metricCustomizer = new MetricCustomizer();
                 metricCustomizer.mbeanFilter = mbeanFilter;
+                metricCustomizer.extraMetrics = extraMetrics;
                 metricCustomizer.attributesAsLabels = attributesAsLabels;
                 cfg.metricCustomizers.add(metricCustomizer);
             }

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -22,6 +22,7 @@ import io.prometheus.jmx.logger.Logger;
 import io.prometheus.jmx.logger.LoggerFactory;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -263,6 +264,18 @@ class JmxScraper {
         if (metricCustomizer != null) {
             attributesAsLabelsWithValues =
                     getAttributesAsLabelsWithValues(metricCustomizer, attributes);
+            for (JmxCollector.ExtraMetric extraMetric : getExtraMetrics(metricCustomizer)) {
+                processBeanValue(
+                        mBeanName,
+                        mBeanDomain,
+                        jmxMBeanPropertyCache.getKeyPropertyList(mBeanName),
+                        attributesAsLabelsWithValues,
+                        new LinkedList<>(),
+                        extraMetric.name,
+                        "UNKNOWN",
+                        extraMetric.description,
+                        extraMetric.value);
+            }
         }
 
         for (Object object : attributes) {
@@ -310,6 +323,13 @@ class JmxScraper {
                         object.getClass().getName());
             }
         }
+    }
+
+    private List<JmxCollector.ExtraMetric> getExtraMetrics(
+            JmxCollector.MetricCustomizer metricCustomizer) {
+        return metricCustomizer.extraMetrics != null
+                ? metricCustomizer.extraMetrics
+                : new ArrayList<>();
     }
 
     private Map<String, String> getAttributesAsLabelsWithValues(JmxCollector.MetricCustomizer metricCustomizer, AttributeList attributes) {

--- a/collector/src/test/java/io/prometheus/jmx/CustomValueMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/CustomValueMBean.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prometheus.jmx;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+/** Class to implement CustomValueMBean */
+public interface CustomValueMBean {
+
+    /**
+     * Method to get the value
+     *
+     * @return value
+     */
+    Integer getValue();
+
+    /**
+     * Method to get the text
+     *
+     * @return text
+     */
+    String getText();
+}
+
+/** Class to implement CustomValue */
+class CustomValue implements CustomValueMBean {
+
+    @Override
+    public Integer getValue() {
+        return 345;
+    }
+
+    @Override
+    public String getText() {
+        return "value";
+    }
+
+    public static void registerBean(MBeanServer mbs) throws javax.management.JMException {
+        ObjectName mbeanName =
+                new ObjectName("io.prometheus.jmx:type=customValue");
+        CustomValueMBean mbean = new CustomValue();
+        mbs.registerMBean(mbean, mbeanName);
+    }
+}

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -57,6 +57,7 @@ public class JmxCollectorTest {
         Bool.registerBean(mbs);
         Camel.registerBean(mbs);
         CustomValue.registerBean(mbs);
+        StringValue.registerBean(mbs);
     }
 
     @Before
@@ -174,6 +175,36 @@ public class JmxCollectorTest {
                 345,
                 getSampleValue(
                         "io_prometheus_jmx_customValue_Value",
+                        new String[] {"Text"},
+                        new String[] {"value"}),
+                .001);
+    }
+
+    @Test
+    public void testMetricCustomizersExtraMetrics() throws Exception {
+        new JmxCollector(
+                        "\n---\nincludeObjectNames: [`io.prometheus.jmx:type=stringValue`]\nmetricCustomizers:\n   - mbeanFilter:\n        domain: io.prometheus.jmx\n        properties:\n           type: stringValue\n     extraMetrics:\n        - name: isActive\n          value: true\n          description: This is a boolean value indicating if the scenario is still active or is completed."
+                                .replace('`', '"'))
+                .register(prometheusRegistry);
+        assertEquals(
+                1.0,
+                getSampleValue(
+                        "io_prometheus_jmx_stringValue_isActive",
+                        new String[] {},
+                        new String[] {}),
+                .001);
+    }
+
+    @Test
+    public void testMetricCustomizersAttributesAsLabelsExtraMetrics() throws Exception {
+        new JmxCollector(
+                        "\n---\nincludeObjectNames: [`io.prometheus.jmx:type=stringValue`]\nmetricCustomizers:\n   - mbeanFilter:\n        domain: io.prometheus.jmx\n        properties:\n           type: stringValue\n     attributesAsLabels:\n        - Text\n     extraMetrics:\n        - name: isActive\n          value: true\n          description: This is a boolean value indicating if the scenario is still active or is completed."
+                                .replace('`', '"'))
+                .register(prometheusRegistry);
+        assertEquals(
+                1.0,
+                getSampleValue(
+                        "io_prometheus_jmx_stringValue_isActive",
                         new String[] {"Text"},
                         new String[] {"value"}),
                 .001);

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -56,6 +56,7 @@ public class JmxCollectorTest {
         TomcatServlet.registerBean(mbs);
         Bool.registerBean(mbs);
         Camel.registerBean(mbs);
+        CustomValue.registerBean(mbs);
     }
 
     @Before
@@ -160,6 +161,21 @@ public class JmxCollectorTest {
                         "hadoop_service_DataNode_",
                         new String[] {"hadoop_service_DataNode_"},
                         new String[] {"hadoop<service=DataNode, "}),
+                .001);
+    }
+
+    @Test
+    public void testMetricCustomizers() throws Exception {
+        new JmxCollector(
+                        "\n---\nincludeObjectNames: [`io.prometheus.jmx:type=customValue`]\nmetricCustomizers:\n   - mbeanFilter:\n        domain: io.prometheus.jmx\n        properties:\n           type: customValue\n     attributesAsLabels:\n        - Text"
+                                .replace('`', '"'))
+                .register(prometheusRegistry);
+        assertEquals(
+                345,
+                getSampleValue(
+                        "io_prometheus_jmx_customValue_Value",
+                        new String[] {"Text"},
+                        new String[] {"value"}),
                 .001);
     }
 

--- a/collector/src/test/java/io/prometheus/jmx/StringValueMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/StringValueMBean.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prometheus.jmx;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+/** Class to implement StringValueMBean */
+public interface StringValueMBean {
+
+    /**
+     * Method to get the text
+     *
+     * @return text
+     */
+    String getText();
+}
+
+/** Class to implement StringValue */
+class StringValue implements StringValueMBean {
+
+    @Override
+    public String getText() {
+        return "value";
+    }
+
+    public static void registerBean(MBeanServer mbs) throws javax.management.JMException {
+        ObjectName mbeanName =
+                new ObjectName("io.prometheus.jmx:type=stringValue");
+        StringValueMBean mbean = new StringValue();
+        mbs.registerMBean(mbean, mbeanName);
+    }
+}

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/MetricCustomizersAttributesAsLabelsExtraMetricsTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/MetricCustomizersAttributesAsLabelsExtraMetricsTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prometheus.jmx.test.core;
+
+import io.prometheus.jmx.test.support.ExporterPath;
+import io.prometheus.jmx.test.support.ExporterTestEnvironment;
+import io.prometheus.jmx.test.support.TestSupport;
+import io.prometheus.jmx.test.support.http.HttpClient;
+import io.prometheus.jmx.test.support.http.HttpHeader;
+import io.prometheus.jmx.test.support.http.HttpResponse;
+import io.prometheus.jmx.test.support.metrics.Metric;
+import io.prometheus.jmx.test.support.metrics.MetricsContentType;
+import io.prometheus.jmx.test.support.metrics.MetricsParser;
+import org.testcontainers.containers.Network;
+import org.verifyica.api.ArgumentContext;
+import org.verifyica.api.ClassContext;
+import org.verifyica.api.Trap;
+import org.verifyica.api.Verifyica;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static io.prometheus.jmx.test.support.Assertions.assertCommonMetricsResponse;
+import static io.prometheus.jmx.test.support.Assertions.assertHealthyResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MetricCustomizersAttributesAsLabelsExtraMetricsTest {
+
+    @Verifyica.ArgumentSupplier(parallelism = Integer.MAX_VALUE)
+    public static Stream<ExporterTestEnvironment> arguments() {
+        return ExporterTestEnvironment.createExporterTestEnvironments();
+    }
+
+    @Verifyica.Prepare
+    public static void prepare(ClassContext classContext) {
+        TestSupport.getOrCreateNetwork(classContext);
+    }
+
+    @Verifyica.BeforeAll
+    public void beforeAll(ArgumentContext argumentContext) {
+        Class<?> testClass = argumentContext.classContext().testClass();
+        Network network = TestSupport.getOrCreateNetwork(argumentContext);
+        TestSupport.initializeExporterTestEnvironment(argumentContext, network, testClass);
+    }
+
+    @Verifyica.Test
+    @Verifyica.Order(1)
+    public void testHealthy(ExporterTestEnvironment exporterTestEnvironment) throws
+            IOException {
+        String url = exporterTestEnvironment.getUrl(ExporterPath.HEALTHY);
+
+        HttpResponse httpResponse = HttpClient.sendRequest(url);
+
+        assertHealthyResponse(httpResponse);
+    }
+
+    @Verifyica.Test
+    public void testDefaultTextMetrics(ExporterTestEnvironment exporterTestEnvironment)
+            throws IOException {
+        String url = exporterTestEnvironment.getUrl(ExporterPath.METRICS);
+
+        HttpResponse httpResponse = HttpClient.sendRequest(url);
+
+        assertMetricsResponse(exporterTestEnvironment, httpResponse, MetricsContentType.DEFAULT);
+    }
+
+    @Verifyica.Test
+    public void testOpenMetricsTextMetrics(ExporterTestEnvironment exporterTestEnvironment)
+            throws IOException {
+        String url = exporterTestEnvironment.getUrl(ExporterPath.METRICS);
+
+        HttpResponse httpResponse =
+                HttpClient.sendRequest(
+                        url,
+                        HttpHeader.ACCEPT,
+                        MetricsContentType.OPEN_METRICS_TEXT_METRICS.toString());
+
+        assertMetricsResponse(
+                exporterTestEnvironment,
+                httpResponse,
+                MetricsContentType.OPEN_METRICS_TEXT_METRICS);
+    }
+
+    @Verifyica.Test
+    public void testPrometheusTextMetrics(ExporterTestEnvironment exporterTestEnvironment)
+            throws IOException {
+        String url = exporterTestEnvironment.getUrl(ExporterPath.METRICS);
+
+        HttpResponse httpResponse =
+                HttpClient.sendRequest(
+                        url,
+                        HttpHeader.ACCEPT,
+                        MetricsContentType.PROMETHEUS_TEXT_METRICS.toString());
+
+        assertMetricsResponse(
+                exporterTestEnvironment, httpResponse,
+                MetricsContentType.PROMETHEUS_TEXT_METRICS);
+    }
+
+    @Verifyica.Test
+    public void testPrometheusProtobufMetrics(ExporterTestEnvironment exporterTestEnvironment)
+            throws IOException {
+        String url = exporterTestEnvironment.getUrl(ExporterPath.METRICS);
+
+        HttpResponse httpResponse =
+                HttpClient.sendRequest(
+                        url,
+                        HttpHeader.ACCEPT,
+                        MetricsContentType.PROMETHEUS_PROTOBUF_METRICS.toString());
+
+        assertMetricsResponse(
+                exporterTestEnvironment,
+                httpResponse,
+                MetricsContentType.PROMETHEUS_PROTOBUF_METRICS);
+    }
+
+    @Verifyica.AfterAll
+    public void afterAll(ArgumentContext argumentContext) throws Throwable {
+        List<Trap> traps = new ArrayList<>();
+
+        traps.add(new Trap(() -> TestSupport.destroyExporterTestEnvironment(argumentContext)));
+        traps.add(new Trap(() -> TestSupport.destroyNetwork(argumentContext)));
+
+        Trap.assertEmpty(traps);
+    }
+
+    @Verifyica.Conclude
+    public static void conclude(ClassContext classContext) throws Throwable {
+        new Trap(() -> TestSupport.destroyNetwork(classContext)).assertEmpty();
+    }
+
+    private void assertMetricsResponse(
+            ExporterTestEnvironment exporterTestEnvironment,
+            HttpResponse httpResponse,
+            MetricsContentType metricsContentType) {
+        assertCommonMetricsResponse(httpResponse, metricsContentType);
+
+        Collection<Metric> metrics = MetricsParser.parseCollection(httpResponse);
+
+        metrics.stream()
+                .filter(metric -> metric.name().equals("io_prometheus_jmx_stringValue_isActive"))
+                .forEach(
+                        metric -> {
+                            assertThat(metric.value())
+                                    .isEqualTo(1);
+                            assertThat(metric.labels())
+                                    .containsEntry("Text", "value");
+                        });
+    }
+}

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/MetricCustomizersExtraMetricsTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/MetricCustomizersExtraMetricsTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prometheus.jmx.test.core;
+
+import static io.prometheus.jmx.test.support.Assertions.assertCommonMetricsResponse;
+import static io.prometheus.jmx.test.support.Assertions.assertHealthyResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.prometheus.jmx.test.support.ExporterPath;
+import io.prometheus.jmx.test.support.ExporterTestEnvironment;
+import io.prometheus.jmx.test.support.TestSupport;
+import io.prometheus.jmx.test.support.http.HttpClient;
+import io.prometheus.jmx.test.support.http.HttpHeader;
+import io.prometheus.jmx.test.support.http.HttpResponse;
+import io.prometheus.jmx.test.support.metrics.Metric;
+import io.prometheus.jmx.test.support.metrics.MetricsContentType;
+import io.prometheus.jmx.test.support.metrics.MetricsParser;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Stream;
+
+import org.testcontainers.containers.Network;
+import org.verifyica.api.ArgumentContext;
+import org.verifyica.api.ClassContext;
+import org.verifyica.api.Trap;
+import org.verifyica.api.Verifyica;
+
+public class MetricCustomizersExtraMetricsTest {
+
+    @Verifyica.ArgumentSupplier(parallelism = Integer.MAX_VALUE)
+    public static Stream<ExporterTestEnvironment> arguments() {
+        return ExporterTestEnvironment.createExporterTestEnvironments();
+    }
+
+    @Verifyica.Prepare
+    public static void prepare(ClassContext classContext) {
+        TestSupport.getOrCreateNetwork(classContext);
+    }
+
+    @Verifyica.BeforeAll
+    public void beforeAll(ArgumentContext argumentContext) {
+        Class<?> testClass = argumentContext.classContext().testClass();
+        Network network = TestSupport.getOrCreateNetwork(argumentContext);
+        TestSupport.initializeExporterTestEnvironment(argumentContext, network, testClass);
+    }
+
+    @Verifyica.Test
+    @Verifyica.Order(1)
+    public void testHealthy(ExporterTestEnvironment exporterTestEnvironment) throws
+            IOException {
+        String url = exporterTestEnvironment.getUrl(ExporterPath.HEALTHY);
+
+        HttpResponse httpResponse = HttpClient.sendRequest(url);
+
+        assertHealthyResponse(httpResponse);
+    }
+
+    @Verifyica.Test
+    public void testDefaultTextMetrics(ExporterTestEnvironment exporterTestEnvironment)
+            throws IOException {
+        String url = exporterTestEnvironment.getUrl(ExporterPath.METRICS);
+
+        HttpResponse httpResponse = HttpClient.sendRequest(url);
+
+        assertMetricsResponse(exporterTestEnvironment, httpResponse, MetricsContentType.DEFAULT);
+    }
+
+    @Verifyica.Test
+    public void testOpenMetricsTextMetrics(ExporterTestEnvironment exporterTestEnvironment)
+            throws IOException {
+        String url = exporterTestEnvironment.getUrl(ExporterPath.METRICS);
+
+        HttpResponse httpResponse =
+                HttpClient.sendRequest(
+                        url,
+                        HttpHeader.ACCEPT,
+                        MetricsContentType.OPEN_METRICS_TEXT_METRICS.toString());
+
+        assertMetricsResponse(
+                exporterTestEnvironment,
+                httpResponse,
+                MetricsContentType.OPEN_METRICS_TEXT_METRICS);
+    }
+
+    @Verifyica.Test
+    public void testPrometheusTextMetrics(ExporterTestEnvironment exporterTestEnvironment)
+            throws IOException {
+        String url = exporterTestEnvironment.getUrl(ExporterPath.METRICS);
+
+        HttpResponse httpResponse =
+                HttpClient.sendRequest(
+                        url,
+                        HttpHeader.ACCEPT,
+                        MetricsContentType.PROMETHEUS_TEXT_METRICS.toString());
+
+        assertMetricsResponse(
+                exporterTestEnvironment, httpResponse,
+                MetricsContentType.PROMETHEUS_TEXT_METRICS);
+    }
+
+    @Verifyica.Test
+    public void testPrometheusProtobufMetrics(ExporterTestEnvironment exporterTestEnvironment)
+            throws IOException {
+        String url = exporterTestEnvironment.getUrl(ExporterPath.METRICS);
+
+        HttpResponse httpResponse =
+                HttpClient.sendRequest(
+                        url,
+                        HttpHeader.ACCEPT,
+                        MetricsContentType.PROMETHEUS_PROTOBUF_METRICS.toString());
+
+        assertMetricsResponse(
+                exporterTestEnvironment,
+                httpResponse,
+                MetricsContentType.PROMETHEUS_PROTOBUF_METRICS);
+    }
+
+    @Verifyica.AfterAll
+    public void afterAll(ArgumentContext argumentContext) throws Throwable {
+        List<Trap> traps = new ArrayList<>();
+
+        traps.add(new Trap(() -> TestSupport.destroyExporterTestEnvironment(argumentContext)));
+        traps.add(new Trap(() -> TestSupport.destroyNetwork(argumentContext)));
+
+        Trap.assertEmpty(traps);
+    }
+
+    @Verifyica.Conclude
+    public static void conclude(ClassContext classContext) throws Throwable {
+        new Trap(() -> TestSupport.destroyNetwork(classContext)).assertEmpty();
+    }
+
+    private void assertMetricsResponse(
+            ExporterTestEnvironment exporterTestEnvironment,
+            HttpResponse httpResponse,
+            MetricsContentType metricsContentType) {
+        assertCommonMetricsResponse(httpResponse, metricsContentType);
+
+        Collection<Metric> metrics = MetricsParser.parseCollection(httpResponse);
+
+        /*
+         * Assert that the mbean has a certain metric
+         */
+        metrics.stream()
+                .filter(metric -> metric.name().equals("io_prometheus_jmx_stringValue_isActive"))
+                .forEach(
+                        metric ->
+                                assertThat(metric.value())
+                                        .isEqualTo(1));
+    }
+}

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/MetricCustomizersTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/MetricCustomizersTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prometheus.jmx.test.core;
+
+import static io.prometheus.jmx.test.support.Assertions.assertCommonMetricsResponse;
+import static io.prometheus.jmx.test.support.Assertions.assertHealthyResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.prometheus.jmx.test.support.ExporterPath;
+import io.prometheus.jmx.test.support.ExporterTestEnvironment;
+import io.prometheus.jmx.test.support.TestSupport;
+import io.prometheus.jmx.test.support.http.HttpClient;
+import io.prometheus.jmx.test.support.http.HttpHeader;
+import io.prometheus.jmx.test.support.http.HttpResponse;
+import io.prometheus.jmx.test.support.metrics.Metric;
+import io.prometheus.jmx.test.support.metrics.MetricsContentType;
+import io.prometheus.jmx.test.support.metrics.MetricsParser;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Stream;
+import org.testcontainers.containers.Network;
+import org.verifyica.api.ArgumentContext;
+import org.verifyica.api.ClassContext;
+import org.verifyica.api.Trap;
+import org.verifyica.api.Verifyica;
+
+public class MetricCustomizersTest {
+
+    @Verifyica.ArgumentSupplier(parallelism = Integer.MAX_VALUE)
+    public static Stream<ExporterTestEnvironment> arguments() {
+        return ExporterTestEnvironment.createExporterTestEnvironments();
+    }
+
+    @Verifyica.Prepare
+    public static void prepare(ClassContext classContext) {
+        TestSupport.getOrCreateNetwork(classContext);
+    }
+
+    @Verifyica.BeforeAll
+    public void beforeAll(ArgumentContext argumentContext) {
+        Class<?> testClass = argumentContext.classContext().testClass();
+        Network network = TestSupport.getOrCreateNetwork(argumentContext);
+        TestSupport.initializeExporterTestEnvironment(argumentContext, network, testClass);
+    }
+
+    @Verifyica.Test
+    @Verifyica.Order(1)
+    public void testHealthy(ExporterTestEnvironment exporterTestEnvironment) throws IOException {
+        String url = exporterTestEnvironment.getUrl(ExporterPath.HEALTHY);
+
+        HttpResponse httpResponse = HttpClient.sendRequest(url);
+
+        assertHealthyResponse(httpResponse);
+    }
+
+    @Verifyica.Test
+    public void testDefaultTextMetrics(ExporterTestEnvironment exporterTestEnvironment)
+            throws IOException {
+        String url = exporterTestEnvironment.getUrl(ExporterPath.METRICS);
+
+        HttpResponse httpResponse = HttpClient.sendRequest(url);
+
+        assertMetricsResponse(exporterTestEnvironment, httpResponse, MetricsContentType.DEFAULT);
+    }
+
+    @Verifyica.Test
+    public void testOpenMetricsTextMetrics(ExporterTestEnvironment exporterTestEnvironment)
+            throws IOException {
+        String url = exporterTestEnvironment.getUrl(ExporterPath.METRICS);
+
+        HttpResponse httpResponse =
+                HttpClient.sendRequest(
+                        url,
+                        HttpHeader.ACCEPT,
+                        MetricsContentType.OPEN_METRICS_TEXT_METRICS.toString());
+
+        assertMetricsResponse(
+                exporterTestEnvironment,
+                httpResponse,
+                MetricsContentType.OPEN_METRICS_TEXT_METRICS);
+    }
+
+    @Verifyica.Test
+    public void testPrometheusTextMetrics(ExporterTestEnvironment exporterTestEnvironment)
+            throws IOException {
+        String url = exporterTestEnvironment.getUrl(ExporterPath.METRICS);
+
+        HttpResponse httpResponse =
+                HttpClient.sendRequest(
+                        url,
+                        HttpHeader.ACCEPT,
+                        MetricsContentType.PROMETHEUS_TEXT_METRICS.toString());
+
+        assertMetricsResponse(
+                exporterTestEnvironment, httpResponse, MetricsContentType.PROMETHEUS_TEXT_METRICS);
+    }
+
+    @Verifyica.Test
+    public void testPrometheusProtobufMetrics(ExporterTestEnvironment exporterTestEnvironment)
+            throws IOException {
+        String url = exporterTestEnvironment.getUrl(ExporterPath.METRICS);
+
+        HttpResponse httpResponse =
+                HttpClient.sendRequest(
+                        url,
+                        HttpHeader.ACCEPT,
+                        MetricsContentType.PROMETHEUS_PROTOBUF_METRICS.toString());
+
+        assertMetricsResponse(
+                exporterTestEnvironment,
+                httpResponse,
+                MetricsContentType.PROMETHEUS_PROTOBUF_METRICS);
+    }
+
+    @Verifyica.AfterAll
+    public void afterAll(ArgumentContext argumentContext) throws Throwable {
+        List<Trap> traps = new ArrayList<>();
+
+        traps.add(new Trap(() -> TestSupport.destroyExporterTestEnvironment(argumentContext)));
+        traps.add(new Trap(() -> TestSupport.destroyNetwork(argumentContext)));
+
+        Trap.assertEmpty(traps);
+    }
+
+    @Verifyica.Conclude
+    public static void conclude(ClassContext classContext) throws Throwable {
+        new Trap(() -> TestSupport.destroyNetwork(classContext)).assertEmpty();
+    }
+
+    private void assertMetricsResponse(
+            ExporterTestEnvironment exporterTestEnvironment,
+            HttpResponse httpResponse,
+            MetricsContentType metricsContentType) {
+        assertCommonMetricsResponse(httpResponse, metricsContentType);
+
+        Collection<Metric> metrics = MetricsParser.parseCollection(httpResponse);
+
+        /*
+         * Assert that a certain metric has specific labels
+         */
+        metrics.stream()
+                .filter(metric -> metric.name().contains("io_prometheus_jmx_customValue_Value"))
+                .forEach(
+                        metric ->
+                                assertThat(metric.labels())
+                                        .containsEntry("Text", "value"));
+    }
+}

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersAttributesAsLabelsExtraMetricsTest/JavaAgent/application.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersAttributesAsLabelsExtraMetricsTest/JavaAgent/application.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+java \
+  -Xmx512M \
+  -javaagent:jmx_prometheus_javaagent.jar=8888:exporter.yaml \
+  -jar jmx_example_application.jar

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersAttributesAsLabelsExtraMetricsTest/JavaAgent/exporter.yaml
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersAttributesAsLabelsExtraMetricsTest/JavaAgent/exporter.yaml
@@ -1,0 +1,12 @@
+includeObjectNames: ["io.prometheus.jmx:type=stringValue"]
+metricCustomizers:
+  - mbeanFilter:
+      domain: io.prometheus.jmx
+      properties:
+        type: stringValue
+    attributesAsLabels:
+      - Text
+    extraMetrics:
+      - name: isActive
+        value: true
+        description: This is a boolean value indicating if the scenario is still active or is completed.

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersAttributesAsLabelsExtraMetricsTest/Standalone/application.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersAttributesAsLabelsExtraMetricsTest/Standalone/application.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+java \
+  -Xmx512M \
+  -Dcom.sun.management.jmxremote=true \
+  -Dcom.sun.management.jmxremote.authenticate=false \
+  -Dcom.sun.management.jmxremote.local.only=false \
+  -Dcom.sun.management.jmxremote.port=9999 \
+  -Dcom.sun.management.jmxremote.registry.ssl=false \
+  -Dcom.sun.management.jmxremote.rmi.port=9999 \
+  -Dcom.sun.management.jmxremote.ssl.need.client.auth=false \
+  -Dcom.sun.management.jmxremote.ssl=false \
+  -jar jmx_example_application.jar

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersAttributesAsLabelsExtraMetricsTest/Standalone/exporter.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersAttributesAsLabelsExtraMetricsTest/Standalone/exporter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+java \
+  -Xmx512M \
+  -jar jmx_prometheus_standalone.jar 8888 exporter.yaml

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersAttributesAsLabelsExtraMetricsTest/Standalone/exporter.yaml
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersAttributesAsLabelsExtraMetricsTest/Standalone/exporter.yaml
@@ -1,0 +1,13 @@
+hostPort: application:9999
+includeObjectNames: ["io.prometheus.jmx:type=stringValue"]
+metricCustomizers:
+  - mbeanFilter:
+      domain: io.prometheus.jmx
+      properties:
+        type: stringValue
+    attributesAsLabels:
+      - Text
+    extraMetrics:
+      - name: isActive
+        value: true
+        description: This is a boolean value indicating if the scenario is still active or is completed.

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersExtraMetricsTest/JavaAgent/application.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersExtraMetricsTest/JavaAgent/application.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+java \
+  -Xmx512M \
+  -javaagent:jmx_prometheus_javaagent.jar=8888:exporter.yaml \
+  -jar jmx_example_application.jar

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersExtraMetricsTest/JavaAgent/exporter.yaml
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersExtraMetricsTest/JavaAgent/exporter.yaml
@@ -1,0 +1,10 @@
+includeObjectNames: ["io.prometheus.jmx:type=stringValue"]
+metricCustomizers:
+  - mbeanFilter:
+      domain: io.prometheus.jmx
+      properties:
+        type: stringValue
+    extraMetrics:
+      - name: isActive
+        value: true
+        description: This is a boolean value indicating if the scenario is still active or is completed.

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersExtraMetricsTest/Standalone/application.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersExtraMetricsTest/Standalone/application.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+java \
+  -Xmx512M \
+  -Dcom.sun.management.jmxremote=true \
+  -Dcom.sun.management.jmxremote.authenticate=false \
+  -Dcom.sun.management.jmxremote.local.only=false \
+  -Dcom.sun.management.jmxremote.port=9999 \
+  -Dcom.sun.management.jmxremote.registry.ssl=false \
+  -Dcom.sun.management.jmxremote.rmi.port=9999 \
+  -Dcom.sun.management.jmxremote.ssl.need.client.auth=false \
+  -Dcom.sun.management.jmxremote.ssl=false \
+  -jar jmx_example_application.jar

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersExtraMetricsTest/Standalone/exporter.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersExtraMetricsTest/Standalone/exporter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+java \
+  -Xmx512M \
+  -jar jmx_prometheus_standalone.jar 8888 exporter.yaml

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersExtraMetricsTest/Standalone/exporter.yaml
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersExtraMetricsTest/Standalone/exporter.yaml
@@ -1,0 +1,11 @@
+hostPort: application:9999
+includeObjectNames: ["io.prometheus.jmx:type=stringValue"]
+metricCustomizers:
+  - mbeanFilter:
+      domain: io.prometheus.jmx
+      properties:
+        type: stringValue
+    extraMetrics:
+      - name: isActive
+        value: true
+        description: This is a boolean value indicating if the scenario is still active or is completed.

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersTest/JavaAgent/application.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersTest/JavaAgent/application.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+java \
+  -Xmx512M \
+  -javaagent:jmx_prometheus_javaagent.jar=8888:exporter.yaml \
+  -jar jmx_example_application.jar

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersTest/JavaAgent/exporter.yaml
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersTest/JavaAgent/exporter.yaml
@@ -1,0 +1,8 @@
+includeObjectNames: ["io.prometheus.jmx:type=customValue"]
+metricCustomizers:
+  - mbeanFilter:
+      domain: io.prometheus.jmx
+      properties:
+        type: customValue
+    attributesAsLabels:
+      - Text

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersTest/Standalone/application.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersTest/Standalone/application.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+java \
+  -Xmx512M \
+  -Dcom.sun.management.jmxremote=true \
+  -Dcom.sun.management.jmxremote.authenticate=false \
+  -Dcom.sun.management.jmxremote.local.only=false \
+  -Dcom.sun.management.jmxremote.port=9999 \
+  -Dcom.sun.management.jmxremote.registry.ssl=false \
+  -Dcom.sun.management.jmxremote.rmi.port=9999 \
+  -Dcom.sun.management.jmxremote.ssl.need.client.auth=false \
+  -Dcom.sun.management.jmxremote.ssl=false \
+  -jar jmx_example_application.jar

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersTest/Standalone/exporter.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersTest/Standalone/exporter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+java \
+  -Xmx512M \
+  -jar jmx_prometheus_standalone.jar 8888 exporter.yaml

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersTest/Standalone/exporter.yaml
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/core/MetricCustomizersTest/Standalone/exporter.yaml
@@ -1,0 +1,9 @@
+hostPort: application:9999
+includeObjectNames: ["io.prometheus.jmx:type=customValue"]
+metricCustomizers:
+  - mbeanFilter:
+      domain: io.prometheus.jmx
+      properties:
+        type: customValue
+    attributesAsLabels:
+      - Text

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/CustomValueMBean.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/CustomValueMBean.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prometheus.jmx;
+
+/** Class to implement CustomValueMBean */
+public interface CustomValueMBean {
+
+    /**
+     * Method to get the value
+     *
+     * @return value
+     */
+    Integer getValue();
+
+    /**
+     * Method to get the text
+     *
+     * @return text
+     */
+    String getText();
+}
+
+/** Class to implement CustomValue */
+class CustomValue implements CustomValueMBean {
+
+    /** Constructor */
+    public CustomValue() {
+        // INTENTIONALLY BLANK
+    }
+
+    @Override
+    public Integer getValue() {
+        return 345;
+    }
+
+    @Override
+    public String getText() {
+        return "value";
+    }
+}

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/JmxExampleApplication.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/JmxExampleApplication.java
@@ -62,6 +62,9 @@ public class JmxExampleApplication {
         mBeanServer.registerMBean(
                 new CustomValue(), new ObjectName("io.prometheus.jmx:type=customValue"));
 
+        mBeanServer.registerMBean(
+                new StringValue(), new ObjectName("io.prometheus.jmx:type=stringValue"));
+
         System.out.printf(
                 "%s | %s | INFO | %s | %s%n",
                 LocalDateTime.now().format(DATE_TIME_FORMATTER),

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/JmxExampleApplication.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/JmxExampleApplication.java
@@ -59,6 +59,9 @@ public class JmxExampleApplication {
                 new PerformanceMetrics(),
                 new ObjectName("io.prometheus.jmx.test:name=PerformanceMetricsMBean"));
 
+        mBeanServer.registerMBean(
+                new CustomValue(), new ObjectName("io.prometheus.jmx:type=customValue"));
+
         System.out.printf(
                 "%s | %s | INFO | %s | %s%n",
                 LocalDateTime.now().format(DATE_TIME_FORMATTER),

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/StringValueMBean.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/StringValueMBean.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prometheus.jmx;
+
+/** Class to implement StringValueMBean */
+public interface StringValueMBean {
+
+    /**
+     * Method to get the text
+     *
+     * @return text
+     */
+    String getText();
+}
+
+/** Class to implement CustomValue */
+class StringValue implements StringValueMBean {
+
+    /** Constructor */
+    public StringValue() {
+        // INTENTIONALLY BLANK
+    }
+
+    @Override
+    public String getText() {
+        return "value";
+    }
+}


### PR DESCRIPTION
This PR has a dependency on [PR](https://github.com/prometheus/jmx_exporter/pull/996). If this functionality is of interest then that PR will be merged first and then this one.

Some of our mbeans only have string attributes, so we won't have any metrics at all, as only numeric or boolean attributes will generate values. We have implemented a way to define a custom value via the configuration file. Here is an example: we want to generate a new metric, such as "isActive" with the value true (1.0)
 
includeObjectNames: ["io.prometheus.jmx:type=stringValue"]
metricCustomizers:
  - mbeanFilter:
      domain: io.prometheus.jmx
      properties:
        type: stringValue
    extraMetrics:
      - name: isActive
        value: true
        description: This is a boolean value indicating if the scenario is still active or is completed.
 
If someone does not explicitly configure metricCustomizers, they should see no impact to performance. When the feature is used, we will go through all the elements in the metricCustomizers block and perform string comparison on the domain and the (optional) properties with every MBean that is matched by the defined rules. For those metrics that match, we will create a new metric with defined name and value. The description is used in the "HELP" section of the logs and indicates what purpose the metric serves.