### PR TITLE
Cache sanitized name and labels

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -835,10 +835,9 @@ public class JmxCollector implements MultiCollector {
             // Add to samples.
             LOGGER.log(
                     FINE,
-                    "add metric sample: %s %s %s %s",
+                    "add metric sample: %s %s %s",
                     matchedRule.name,
-                    matchedRule.labelNames,
-                    matchedRule.labelValues,
+                    matchedRule.labels,
                     value.doubleValue());
 
             matchedRules.add(matchedRule.withValue(value.doubleValue()));

--- a/collector/src/main/java/io/prometheus/jmx/MatchedRule.java
+++ b/collector/src/main/java/io/prometheus/jmx/MatchedRule.java
@@ -16,6 +16,7 @@
 
 package io.prometheus.jmx;
 
+import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 import java.util.List;
 import java.util.Objects;
@@ -31,8 +32,7 @@ public class MatchedRule {
     final String matchName;
     final String type;
     final String help;
-    final List<String> labelNames;
-    final List<String> labelValues;
+    final Labels labels;
     final Double value;
     final double valueFactor;
 
@@ -43,8 +43,7 @@ public class MatchedRule {
         this.matchName = null;
         this.type = null;
         this.help = null;
-        this.labelNames = null;
-        this.labelValues = null;
+        this.labels = null;
         this.value = null;
         this.valueFactor = 1.0;
     }
@@ -70,12 +69,39 @@ public class MatchedRule {
             final List<String> labelValues,
             final Double value,
             double valueFactor) {
+        this.name = PrometheusNaming.sanitizeMetricName(name);
+        this.matchName = matchName;
+        this.type = type;
+        this.help = help;
+        this.labels = Labels.of(labelNames, labelValues);
+        this.value = value;
+        this.valueFactor = valueFactor;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param name name - has to be already sanitized (we ensure this by keeping the constructor private)
+     * @param matchName matchName
+     * @param type type
+     * @param help help
+     * @param labels labels
+     * @param value value
+     * @param valueFactor valueFactor
+     */
+    private MatchedRule(
+      final String name,
+      final String matchName,
+      final String type,
+      final String help,
+      final Labels labels,
+      final Double value,
+      double valueFactor) {
         this.name = name;
         this.matchName = matchName;
         this.type = type;
         this.help = help;
-        this.labelNames = labelNames;
-        this.labelValues = labelValues;
+        this.labels = labels;
         this.value = value;
         this.valueFactor = valueFactor;
     }
@@ -88,12 +114,11 @@ public class MatchedRule {
      */
     public MatchedRule withValue(double value) {
         return new MatchedRule(
-                PrometheusNaming.sanitizeMetricName(this.name),
+                this.name,
                 this.matchName,
                 this.type,
                 this.help,
-                this.labelNames,
-                this.labelValues,
+                this.labels,
                 value,
                 this.valueFactor);
     }
@@ -142,10 +167,8 @@ public class MatchedRule {
                 + ", help='"
                 + help
                 + '\''
-                + ", labelNames="
-                + labelNames
-                + ", labelValues="
-                + labelValues
+                + ", labels="
+                + labels
                 + ", value="
                 + value
                 + ", valueFactor="
@@ -163,14 +186,13 @@ public class MatchedRule {
                 && Objects.equals(matchName, that.matchName)
                 && Objects.equals(type, that.type)
                 && Objects.equals(help, that.help)
-                && Objects.equals(labelNames, that.labelNames)
-                && Objects.equals(labelValues, that.labelValues)
+                && Objects.equals(labels, that.labels)
                 && Objects.equals(value, that.value);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(
-                name, matchName, type, help, labelNames, labelValues, value, valueFactor);
+                name, matchName, type, help, labels, value, valueFactor);
     }
 }

--- a/collector/src/main/java/io/prometheus/jmx/MatchedRuleToMetricSnapshotsConverter.java
+++ b/collector/src/main/java/io/prometheus/jmx/MatchedRuleToMetricSnapshotsConverter.java
@@ -90,7 +90,7 @@ public class MatchedRuleToMetricSnapshotsConverter {
                                 .name(rulesWithSameName.get(0).name)
                                 .help(rulesWithSameName.get(0).help);
                 for (MatchedRule rule : rulesWithSameName) {
-                    Labels labels = Labels.of(rule.labelNames, rule.labelValues);
+                    Labels labels = rule.labels;
                     if (!labelsUnique) {
                         labels =
                                 labels.merge(
@@ -112,7 +112,7 @@ public class MatchedRuleToMetricSnapshotsConverter {
                                 .name(rulesWithSameName.get(0).name)
                                 .help(rulesWithSameName.get(0).help);
                 for (MatchedRule rule : rulesWithSameName) {
-                    Labels labels = Labels.of(rule.labelNames, rule.labelValues);
+                    Labels labels = rule.labels;
                     if (!labelsUnique) {
                         labels =
                                 labels.merge(
@@ -134,7 +134,7 @@ public class MatchedRuleToMetricSnapshotsConverter {
                                 .name(rulesWithSameName.get(0).name)
                                 .help(rulesWithSameName.get(0).help);
                 for (MatchedRule rule : rulesWithSameName) {
-                    Labels labels = Labels.of(rule.labelNames, rule.labelValues);
+                    Labels labels = rule.labels;
                     if (!labelsUnique) {
                         labels =
                                 labels.merge(
@@ -164,7 +164,7 @@ public class MatchedRuleToMetricSnapshotsConverter {
     private static boolean isLabelsUnique(List<MatchedRule> rulesWithSameName) {
         Set<Labels> labelsSet = new HashSet<>(rulesWithSameName.size());
         for (MatchedRule matchedRule : rulesWithSameName) {
-            Labels labels = Labels.of(matchedRule.labelNames, matchedRule.labelValues);
+            Labels labels = matchedRule.labels;
             if (labelsSet.contains(labels)) {
                 return false;
             }


### PR DESCRIPTION
Currently the rule matches cache stores unsanitized metric name and labels. That means that sanitization has to be done on each scrape. In my tests that sanitization is responsible for 11% of CPU time (+GC) and 39% of allocations. This cost can be easily avoided by performing the sanitization before caching.

CPU profile (with the relevant parts marked in purple):
![image](https://github.com/user-attachments/assets/40fa3108-8571-44df-95f1-b2d01f2bab8c)

Allocation profile (with the relevant parts marked in purple):
![image](https://github.com/user-attachments/assets/c175a46d-9195-4147-9451-e33a9e242ba4)
