### PR TITLE
Removed copyright year per CNCF recommendations

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/BuildInfoMetrics.java
+++ b/collector/src/main/java/io/prometheus/jmx/BuildInfoMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/main/java/io/prometheus/jmx/JmxMBeanPropertyCache.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxMBeanPropertyCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/main/java/io/prometheus/jmx/MatchedRule.java
+++ b/collector/src/main/java/io/prometheus/jmx/MatchedRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/main/java/io/prometheus/jmx/MatchedRuleToMetricSnapshotsConverter.java
+++ b/collector/src/main/java/io/prometheus/jmx/MatchedRuleToMetricSnapshotsConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/main/java/io/prometheus/jmx/MatchedRulesCache.java
+++ b/collector/src/main/java/io/prometheus/jmx/MatchedRulesCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/main/java/io/prometheus/jmx/ObjectNameAttributeFilter.java
+++ b/collector/src/main/java/io/prometheus/jmx/ObjectNameAttributeFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/main/java/io/prometheus/jmx/logger/Logger.java
+++ b/collector/src/main/java/io/prometheus/jmx/logger/Logger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/main/java/io/prometheus/jmx/logger/LoggerFactory.java
+++ b/collector/src/main/java/io/prometheus/jmx/logger/LoggerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/BeanWithEnumMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/BeanWithEnumMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/BoolMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/BoolMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/BuildInfoMetricsTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/BuildInfoMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/CamelMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/CamelMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/CassandraMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/CassandraMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/CassandraMetricsMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/CassandraMetricsMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/CollidingNameMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/CollidingNameMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/CustomValueMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/CustomValueMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/DuplicateLabels.java
+++ b/collector/src/test/java/io/prometheus/jmx/DuplicateLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/ExistDbMXBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/ExistDbMXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/HadoopDataNodeMXBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/HadoopDataNodeMXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/HadoopMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/HadoopMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/JmxMBeanPropertyCacheTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/JmxMBeanPropertyCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/MatchedRuleToMetricSnapshotsConverterTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/MatchedRuleToMetricSnapshotsConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/ObjectNameAttributeFilterTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/ObjectNameAttributeFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/PerformanceMetricsMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/PerformanceMetricsMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/PrometheusRegistryUtils.java
+++ b/collector/src/test/java/io/prometheus/jmx/PrometheusRegistryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/SafeNameTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/SafeNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/SnakeCaseAttrTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/SnakeCaseAttrTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/State.java
+++ b/collector/src/test/java/io/prometheus/jmx/State.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/StringValueMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/StringValueMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/TomcatPatternCheckTest.java
+++ b/collector/src/test/java/io/prometheus/jmx/TomcatPatternCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/TomcatServletMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/TomcatServletMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/collector/src/test/java/io/prometheus/jmx/TotalValueMBean.java
+++ b/collector/src/test/java/io/prometheus/jmx/TotalValueMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/Assertions.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/Assertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/JavaDockerImages.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/JavaDockerImages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/JmxExporterMode.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/JmxExporterMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/PrometheusDockerImages.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/PrometheusDockerImages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/http/HttpClient.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/http/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/http/HttpHeader.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/http/HttpHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/http/HttpRequest.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/http/HttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/http/HttpResponse.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/http/HttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/http/HttpResponseBody.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/http/HttpResponseBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/metrics/MapMetricAssertion.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/metrics/MapMetricAssertion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/metrics/Metric.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/metrics/Metric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/metrics/MetricAssertion.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/metrics/MetricAssertion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/metrics/MetricsContentType.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/metrics/MetricsContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/metrics/MetricsParser.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/metrics/MetricsParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/metrics/MetricsParserException.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/metrics/MetricsParserException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/throttle/ExponentialBackoffThrottle.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/throttle/ExponentialBackoffThrottle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/throttle/Throttle.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/throttle/Throttle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/AutoIncrementingMBeanTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/AutoIncrementingMBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/BasicIsolatorTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/BasicIsolatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/BasicTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/BasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/BlacklistObjectNamesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/BlacklistObjectNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/CompositeKeyDataTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/CompositeKeyDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/DisableAutoExcludeObjectNameAttributesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/DisableAutoExcludeObjectNameAttributesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/ExcludeObjectNameAttributesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/ExcludeObjectNameAttributesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/ExcludeObjectNamesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/ExcludeObjectNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/IncludeAndExcludeObjectNamesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/IncludeAndExcludeObjectNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/IncludeObjectNameAttributesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/IncludeObjectNameAttributesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/IncludeObjectNamesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/IncludeObjectNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/LowerCaseOutputAndLabelNamesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/LowerCaseOutputAndLabelNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/LowerCaseOutputLabelNamesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/LowerCaseOutputLabelNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/LowerCaseOutputNamesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/LowerCaseOutputNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/MetricCustomizersAttributesAsLabelsExtraMetricsTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/MetricCustomizersAttributesAsLabelsExtraMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/MetricCustomizersExtraMetricsTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/MetricCustomizersExtraMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/MetricCustomizersTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/MetricCustomizersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/OptionalValueMBeanTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/OptionalValueMBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/WhitelistAndBlacklistObjectNamesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/WhitelistAndBlacklistObjectNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/WhitelistObjectNamesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/core/WhitelistObjectNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/CompleteHttpServerConfigurationTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/CompleteHttpServerConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/AuthenticatorPluginTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/AuthenticatorPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationPBKDF2WithHmacSHA1Test.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationPBKDF2WithHmacSHA1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationPBKDF2WithHmacSHA256Test.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationPBKDF2WithHmacSHA256Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationPBKDF2WithHmacSHA512Test.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationPBKDF2WithHmacSHA512Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationPlaintextTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationPlaintextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationSHA1Test.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationSHA1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationSHA256Test.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationSHA256Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationSHA512Test.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/authentication/BasicAuthenticationSHA512Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLAndBasicAuthenticationPBKDF2WithHmacSHA512Test.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLAndBasicAuthenticationPBKDF2WithHmacSHA512Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithJKSKeyStoreMultipleCertificatesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithJKSKeyStoreMultipleCertificatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithJKSKeyStoreTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithJKSKeyStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithJKSKeyStoreTest2.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithJKSKeyStoreTest2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithPKCS12KeyStoreMultipleCertificatesTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithPKCS12KeyStoreMultipleCertificatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithPKCS12KeyStoreTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithPKCS12KeyStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithPKCS12KeyStoreTest2.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithPKCS12KeyStoreTest2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithTrustStoreAndClientAuth.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/ssl/SSLWithTrustStoreAndClientAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/threads/ThreadsConfigurationTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/threads/ThreadsConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/opentelemetry/BasicAuthenticationTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/opentelemetry/BasicAuthenticationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/opentelemetry/BasicTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/opentelemetry/BasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/opentelemetry/CombinedModeTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/opentelemetry/CombinedModeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/opentelemetry/CompleteTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/opentelemetry/CompleteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/opentelemetry/EnvironmentVariablesConfigurationTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/opentelemetry/EnvironmentVariablesConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/opentelemetry/ExpectedMetricsNames.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/opentelemetry/ExpectedMetricsNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/opentelemetry/MixedConfigurationTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/opentelemetry/MixedConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/rmi/ssl/MinimalRMISSLTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/rmi/ssl/MinimalRMISSLTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/rmi/ssl/RMIRegistrySSLDisabledTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/rmi/ssl/RMIRegistrySSLDisabledTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/ExporterPath.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/ExporterPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/ExporterTestEnvironment.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/ExporterTestEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/IsolatorExporterTestEnvironment.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/IsolatorExporterTestEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/OpenTelemetryTestEnvironment.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/OpenTelemetryTestEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/PBKDF2WithHmacExporterTestEnvironmentFilter.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/PBKDF2WithHmacExporterTestEnvironmentFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/PKCS12KeyStoreExporterTestEnvironmentFilter.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/PKCS12KeyStoreExporterTestEnvironmentFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/TestContainerConfigureCmd.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/TestContainerConfigureCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/TestContainerLogger.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/TestContainerLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/TestSupport.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/TestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/AuthenticatorPlugin.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/AuthenticatorPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/AutoIncrementingMBean.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/AutoIncrementingMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/CustomValueMBean.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/CustomValueMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/ExistDbMXBean.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/ExistDbMXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/JmxExampleApplication.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/JmxExampleApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/OptionalValueMBean.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/OptionalValueMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/PerformanceMetricsMBean.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/PerformanceMetricsMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/StringValueMBean.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/StringValueMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/TabularMBean.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/TabularMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ConvertToBoolean.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ConvertToBoolean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ConvertToInteger.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ConvertToInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ConvertToMap.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ConvertToMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ConvertToMapAccessor.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ConvertToMapAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ConvertToString.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ConvertToString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ValidateIntegerInRange.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ValidateIntegerInRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ValidateIsURL.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ValidateIsURL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ValidateMapValues.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ValidateMapValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ValidateStringIsNotBlank.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/configuration/ValidateStringIsNotBlank.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/http/ConfigurationException.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/http/ConfigurationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/http/HTTPServerFactory.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/http/HTTPServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/http/authenticator/Credentials.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/http/authenticator/Credentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/http/authenticator/CredentialsCache.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/http/authenticator/CredentialsCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/http/authenticator/MessageDigestAuthenticator.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/http/authenticator/MessageDigestAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/http/authenticator/PBKDF2Authenticator.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/http/authenticator/PBKDF2Authenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/http/authenticator/PlaintextAuthenticator.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/http/authenticator/PlaintextAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/http/ssl/SSLContextFactory.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/http/ssl/SSLContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/opentelemetry/OpenTelemetryExporterFactory.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/opentelemetry/OpenTelemetryExporterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/tools/CustomServiceTransformer.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/tools/CustomServiceTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/util/Precondition.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/util/Precondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/util/ResourceSupport.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/util/ResourceSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/yaml/YamlMapAccessor.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/yaml/YamlMapAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/HTTPServerFactoryTest.java
+++ b/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/HTTPServerFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/authenticator/BaseAuthenticatorTest.java
+++ b/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/authenticator/BaseAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/authenticator/CredentialsCacheTest.java
+++ b/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/authenticator/CredentialsCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/authenticator/CredentialsTest.java
+++ b/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/authenticator/CredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/authenticator/CustomAuthenticator451.java
+++ b/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/authenticator/CustomAuthenticator451.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/authenticator/CustomAuthenticatorWithSubject.java
+++ b/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/authenticator/CustomAuthenticatorWithSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/authenticator/MessageDigestAuthenticatorTest.java
+++ b/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/authenticator/MessageDigestAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/authenticator/PBKDF2AuthenticatorTest.java
+++ b/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/authenticator/PBKDF2AuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/authenticator/PlaintextAuthenticatorTest.java
+++ b/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/http/authenticator/PlaintextAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/util/PreconditionTest.java
+++ b/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/util/PreconditionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/yaml/YamlMapAccessorTest.java
+++ b/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/yaml/YamlMapAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_isolator_javaagent/src/main/java/io/prometheus/jmx/IsolatorJavaAgent.java
+++ b/jmx_prometheus_isolator_javaagent/src/main/java/io/prometheus/jmx/IsolatorJavaAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_isolator_javaagent/src/main/java/io/prometheus/jmx/JarClassLoader.java
+++ b/jmx_prometheus_isolator_javaagent/src/main/java/io/prometheus/jmx/JarClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/Arguments.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/AutoClosableShutdownHook.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/AutoClosableShutdownHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2023 The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/ArgumentsTest.java
+++ b/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/ArgumentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_standalone/src/main/java/io/prometheus/jmx/Arguments.java
+++ b/jmx_prometheus_standalone/src/main/java/io/prometheus/jmx/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_standalone/src/main/java/io/prometheus/jmx/AutoClosableShutdownHook.java
+++ b/jmx_prometheus_standalone/src/main/java/io/prometheus/jmx/AutoClosableShutdownHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025-present The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jmx_prometheus_standalone/src/main/java/io/prometheus/jmx/Standalone.java
+++ b/jmx_prometheus_standalone/src/main/java/io/prometheus/jmx/Standalone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2023 The Prometheus jmx_exporter Authors
+ * Copyright (C) The Prometheus jmx_exporter Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pipeliner
+++ b/pipeliner
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2024-present Pipeliner project authors and contributors
+# Copyright (C) Pipeliner project authors and contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run-quick-test.sh
+++ b/run-quick-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+# Copyright (C) The Prometheus jmx_exporter Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run-regression-test.sh
+++ b/run-regression-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+# Copyright (C) The Prometheus jmx_exporter Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run-smoke-test.sh
+++ b/run-smoke-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+# Copyright (C) The Prometheus jmx_exporter Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run-stress-test.sh
+++ b/run-stress-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+# Copyright (C) The Prometheus jmx_exporter Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run-targeted-test.sh
+++ b/run-targeted-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2022-present The Prometheus jmx_exporter Authors
+# Copyright (C) The Prometheus jmx_exporter Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Removed copyright year per CNCF recommendations.

https://github.com/cncf/foundation/blob/main/copyright-notices.md
