### PR TITLE
Fixed shading

### DIFF
--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/tools/CustomServiceTransformer.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/tools/CustomServiceTransformer.java
@@ -31,12 +31,12 @@ import org.apache.maven.plugins.shade.relocation.Relocator;
 import org.apache.maven.plugins.shade.resource.ResourceTransformer;
 
 /**
- * CustomServiceTransformer is a ResourceTransformer that modifies the META-INF/services files to
- * add a prefix to service file names and entries
+ * ResourceTransformer that modifies the META-INF/services files to add a prefix to service file
+ * names and entries
  */
 public class CustomServiceTransformer implements ResourceTransformer {
 
-    private static final String PREFIX = "jmx_prometheus_javaagent.";
+    private static final String PREFIX = "e1723a08afd7bca35570fd31a7656f59.";
     private static final String SERVICES_DIR = "META-INF/services/";
 
     private final Map<String, List<String>> serviceEntries = new HashMap<>();

--- a/jmx_prometheus_isolator_javaagent/pom.xml
+++ b/jmx_prometheus_isolator_javaagent/pom.xml
@@ -27,14 +27,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.snakeyaml</groupId>
-            <artifactId>snakeyaml-engine</artifactId>
-            <version>2.9</version>
-        </dependency>
-    </dependencies>
-
     <build>
         <finalName>jmx_prometheus_isolator_javaagent-${project.version}</finalName>
         <plugins>
@@ -136,32 +128,23 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <filters>
-                                <!-- Exclude files from all included dependencies -->
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/LICENSE</exclude>
-                                        <exclude>META-INF/LICENSE.txt</exclude>
-                                        <exclude>META-INF/MANIFEST.MF</exclude>
-                                        <exclude>META-INF/NOTICE</exclude>
-                                        <exclude>META-INF/NOTICE.txt</exclude>
-                                        <exclude>META-INF/versions/**</exclude>
-                                        <exclude>META-INF/maven/**</exclude>
-                                        <exclude>META-INF/org/snakeyaml/**</exclude>
-                                        <exclude>module-info.class</exclude>./mv
-                                    </excludes>
-                                </filter>
-                            </filters>
-                            <!-- Relocate packages -->
-                            <relocations>
-                                <relocation>
-                                    <shadedPattern>jmx_prometheus_isolator_javaagent.</shadedPattern>
-                                    <includes>
-                                        <include>org.snakeyaml.**</include>
-                                    </includes>
-                                </relocation>
-                            </relocations>
+                            <!-- Exclude entire dependencies -->
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.apache.maven.plugins:maven-shade-plugin</exclude>
+                                    <exclude>org.codehaus.plexus:plexus-utils</exclude>
+                                    <exclude>org.slf4j:slf4j-api</exclude>
+                                    <exclude>org.ow2.asm:asm</exclude>
+                                    <exclude>org.ow2.asm:asm-commons</exclude>
+                                    <exclude>org.ow2.asm:asm-tree</exclude>
+                                    <exclude>org.jdom:jdom2</exclude>
+                                    <exclude>org.apache.commons:commons-compress</exclude>
+                                    <exclude>commons-codec:commons-codec</exclude>
+                                    <exclude>org.apache.commons:commons-lang3</exclude>
+                                    <exclude>commons-io:commons-io</exclude>
+                                    <exclude>org.vafer:jdependency</exclude>
+                                </excludes>
+                            </artifactSet>
                             <!-- Transform resources -->
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/jmx_prometheus_isolator_javaagent/src/main/java/io/prometheus/jmx/JarClassLoader.java
+++ b/jmx_prometheus_isolator_javaagent/src/main/java/io/prometheus/jmx/JarClassLoader.java
@@ -155,7 +155,7 @@ public class JarClassLoader extends ClassLoader {
                 String title = null;
                 String version = null;
 
-                if (className.startsWith("jmx_prometheus_javaagent")) {
+                if (className.startsWith("e1723a08afd7bca35570fd31a7656f59")) {
                     title = manifestMap.get(IMPLEMENTATION_TITLE);
                     version = manifestMap.get(IMPLEMENTATION_VERSION);
                 }

--- a/jmx_prometheus_javaagent/pom.xml
+++ b/jmx_prometheus_javaagent/pom.xml
@@ -181,7 +181,7 @@
                             <!-- Relocate packages -->
                             <relocations>
                                 <relocation>
-                                    <shadedPattern>jmx_prometheus_javaagent.</shadedPattern>
+                                    <shadedPattern>e1723a08afd7bca35570fd31a7656f59.</shadedPattern>
                                     <includes>
                                         <include>com.**</include>
                                         <include>google.**</include>
@@ -199,7 +199,7 @@
                                 </relocation>
                                 <relocation>
                                     <pattern>io.prometheus.metrics.shaded</pattern>
-                                    <shadedPattern>jmx_prometheus_javaagent.io.prometheus.metrics.shaded</shadedPattern>
+                                    <shadedPattern>e1723a08afd7bca35570fd31a7656f59.io.prometheus.metrics.shaded</shadedPattern>
                                 </relocation>
                             </relocations>
                             <!-- Transform resources -->

--- a/jmx_prometheus_standalone/pom.xml
+++ b/jmx_prometheus_standalone/pom.xml
@@ -169,7 +169,7 @@
                             <!-- Relocate packages -->
                             <relocations>
                                 <relocation>
-                                    <shadedPattern>jmx_prometheus_javaagent.</shadedPattern>
+                                    <shadedPattern>e1723a08afd7bca35570fd31a7656f59.</shadedPattern>
                                     <includes>
                                         <include>com.**</include>
                                         <include>google.**</include>
@@ -187,7 +187,7 @@
                                 </relocation>
                                 <relocation>
                                     <pattern>io.prometheus.metrics.shaded</pattern>
-                                    <shadedPattern>jmx_prometheus_javaagent.io.prometheus.metrics.shaded</shadedPattern>
+                                    <shadedPattern>e1723a08afd7bca35570fd31a7656f59.io.prometheus.metrics.shaded</shadedPattern>
                                 </relocation>
                             </relocations>
                             <!-- Transform resources -->


### PR DESCRIPTION
Fixed shading. Changed shading prefix to be `e1723a08afd7bca35570fd31a7656f59` md5(Prometheus) due to some shading differences between the Java agent and the Standalone exporter.