### PR TITLE
Fixed integration test startup timing issue

### DIFF
--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/JavaDockerImages.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/JavaDockerImages.java
@@ -53,9 +53,9 @@ public final class JavaDockerImages {
     }
 
     /**
-     * Method to get List of Docker image names filtered by a Predicate
+     * Method to get collection of Docker image names filtered by a Predicate
      *
-     * @return the List of Docker image names
+     * @return the collection of Docker image names
      */
     public static Collection<String> names() {
         String configurationValues =
@@ -75,6 +75,15 @@ public final class JavaDockerImages {
         }
 
         return Collections.unmodifiableList(toList(configurationValues));
+    }
+
+    /**
+     * Method to get a collection of all Docker image names
+     *
+     * @return a collection of all Docker image names
+     */
+    public static Collection<String> allNames() {
+        return ALL_DOCKER_IMAGE_NAMES;
     }
 
     /**

--- a/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/PrometheusDockerImages.java
+++ b/integration_test_suite/integration_tests/src/main/java/io/prometheus/jmx/test/support/PrometheusDockerImages.java
@@ -53,9 +53,9 @@ public final class PrometheusDockerImages {
     }
 
     /**
-     * Method to get List of Docker image names filtered by a Predicate
+     * Method to get a collection of Docker image names filter by configuration
      *
-     * @return the List of Docker image names
+     * @return the collection of Docker image names
      */
     public static Collection<String> names() {
         String configurationValue =
@@ -75,6 +75,15 @@ public final class PrometheusDockerImages {
         }
 
         return Collections.unmodifiableList(toList(configurationValue));
+    }
+
+    /**
+     * Method to get a collection of all Docker image names
+     *
+     * @return a collection of all Docker image names
+     */
+    public static Collection<String> allNames() {
+        return ALL_DOCKER_IMAGE_NAMES;
     }
 
     /**

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/LocalTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/LocalTest.java
@@ -31,6 +31,7 @@ import io.prometheus.jmx.StringValue;
 import io.prometheus.jmx.TabularData;
 import io.prometheus.jmx.common.HTTPServerFactory;
 import io.prometheus.jmx.common.util.ResourceSupport;
+import io.prometheus.jmx.test.support.ExporterPath;
 import io.prometheus.jmx.test.support.Repeater;
 import io.prometheus.jmx.test.support.http.HttpClient;
 import io.prometheus.jmx.test.support.http.HttpHeader;
@@ -140,7 +141,7 @@ public class LocalTest {
     @Verifyica.Test
     @Verifyica.Order(1)
     public void testHealthy(ArgumentContext argumentContext) throws Throwable {
-        String url = argumentContext.classContext().map().getAs(URL) + "/-/healthy";
+        String url = argumentContext.classContext().map().getAs(URL) + ExporterPath.HEALTHY;
 
         HttpResponse httpResponse = HttpClient.sendRequest(url);
 
@@ -149,7 +150,7 @@ public class LocalTest {
 
     @Verifyica.Test
     public void testDefaultTextMetrics(ArgumentContext argumentContext) throws Throwable {
-        String url = argumentContext.classContext().map().getAs(URL) + "/metrics";
+        String url = argumentContext.classContext().map().getAs(URL) + ExporterPath.METRICS;
 
         // Run the test code multiple times
         new Repeater(ITERATIONS)
@@ -165,7 +166,7 @@ public class LocalTest {
 
     @Verifyica.Test
     public void testOpenMetricsTextMetrics(ArgumentContext argumentContext) throws Throwable {
-        String url = argumentContext.classContext().map().getAs(URL) + "/metrics";
+        String url = argumentContext.classContext().map().getAs(URL) + ExporterPath.METRICS;
 
         // Run the test code multiple times
         new Repeater(ITERATIONS)
@@ -187,7 +188,7 @@ public class LocalTest {
 
     @Verifyica.Test
     public void testPrometheusTextMetrics(ArgumentContext argumentContext) throws Throwable {
-        String url = argumentContext.classContext().map().getAs(URL) + "/metrics";
+        String url = argumentContext.classContext().map().getAs(URL) + ExporterPath.METRICS;
 
         // Run the test code multiple times
         new Repeater(ITERATIONS)
@@ -208,7 +209,7 @@ public class LocalTest {
 
     @Verifyica.Test
     public void testPrometheusProtobufMetrics(ArgumentContext argumentContext) throws Throwable {
-        String url = argumentContext.classContext().map().getAs(URL) + "/metrics";
+        String url = argumentContext.classContext().map().getAs(URL) + ExporterPath.METRICS;
 
         // Run the test code multiple times
         new Repeater(ITERATIONS)
@@ -312,6 +313,20 @@ public class LocalTest {
                 .withName(
                         "io_prometheus_jmx_test_PerformanceMetricsMBean_PerformanceMetrics_BootstrapsDeferred")
                 .withValue(6.0d)
+                .isPresent();
+
+        assertMetric(metrics)
+                .ofType(Metric.Type.UNTYPED)
+                .withName("org_exist_management_exist_ProcessReport_RunningQueries_id")
+                .withLabel("key_id", "1")
+                .withLabel("key_path", "/db/query1.xq")
+                .isPresent();
+
+        assertMetric(metrics)
+                .ofType(Metric.Type.UNTYPED)
+                .withName("org_exist_management_exist_ProcessReport_RunningQueries_id")
+                .withLabel("key_id", "2")
+                .withLabel("key_path", "/db/query2.xq")
                 .isPresent();
     }
 }

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/ExporterTestEnvironment.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/ExporterTestEnvironment.java
@@ -23,7 +23,6 @@ import java.util.stream.Stream;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.verifyica.api.Argument;
 
@@ -194,8 +193,8 @@ public class ExporterTestEnvironment implements Argument<ExporterTestEnvironment
                 .withLogConsumer(TestContainerLogger.getInstance())
                 .withNetwork(network)
                 .withNetworkAliases("application")
-                .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
-                .withStartupTimeout(Duration.ofMillis(60000))
+                .waitingFor(Wait.forLogMessage(".*JmxExampleApplication \\| Running.*", 1))
+                .withStartupTimeout(Duration.ofSeconds(60))
                 .withWorkingDirectory("/temp");
     }
 
@@ -218,7 +217,7 @@ public class ExporterTestEnvironment implements Argument<ExporterTestEnvironment
                 .withLogConsumer(TestContainerLogger.getInstance())
                 .withNetwork(network)
                 .withNetworkAliases("application")
-                .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
+                .waitingFor(Wait.forLogMessage(".*JmxExampleApplication \\| Running.*", 1))
                 .withStartupTimeout(Duration.ofMillis(60000))
                 .withWorkingDirectory("/temp");
     }
@@ -242,8 +241,7 @@ public class ExporterTestEnvironment implements Argument<ExporterTestEnvironment
                 .withLogConsumer(TestContainerLogger.getInstance())
                 .withNetwork(network)
                 .withNetworkAliases("exporter")
-                .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
-                .withStartupTimeout(Duration.ofMillis(60000))
+                .waitingFor(Wait.forLogMessage(".*Standalone \\| Running.*", 1))
                 .withWorkingDirectory("/temp");
     }
 

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/OpenTelemetryTestEnvironment.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/support/OpenTelemetryTestEnvironment.java
@@ -29,7 +29,6 @@ import java.util.stream.Stream;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.verifyica.api.Argument;
 
@@ -294,7 +293,6 @@ public class OpenTelemetryTestEnvironment implements Argument<OpenTelemetryTestE
                                 })
                         .withNetwork(network)
                         .withNetworkAliases("prometheus")
-                        .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
                         .withStartupTimeout(Duration.ofMillis(60000))
                         .waitingFor(
                                 Wait.forLogMessage(
@@ -327,7 +325,7 @@ public class OpenTelemetryTestEnvironment implements Argument<OpenTelemetryTestE
                 .withLogConsumer(TestContainerLogger.getInstance())
                 .withNetwork(network)
                 .withNetworkAliases("application")
-                .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
+                .waitingFor(Wait.forLogMessage(".*JmxExampleApplication \\| Running.*", 1))
                 .withStartupTimeout(Duration.ofMillis(60000))
                 .withWorkingDirectory("/temp");
     }
@@ -351,10 +349,9 @@ public class OpenTelemetryTestEnvironment implements Argument<OpenTelemetryTestE
                 .withLogConsumer(TestContainerLogger.getInstance())
                 .withNetwork(network)
                 .withNetworkAliases("application")
-                .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
+                .waitingFor(Wait.forLogMessage(".*JmxExampleApplication \\| Running.*", 1))
                 .withStartupTimeout(Duration.ofMillis(60000))
-                .withWorkingDirectory("/temp")
-                .waitingFor(Wait.forLogMessage(".*Running.*", 1));
+                .withWorkingDirectory("/temp");
     }
 
     /**
@@ -376,7 +373,7 @@ public class OpenTelemetryTestEnvironment implements Argument<OpenTelemetryTestE
                 .withLogConsumer(TestContainerLogger.getInstance())
                 .withNetwork(network)
                 .withNetworkAliases("exporter")
-                .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
+                .waitingFor(Wait.forLogMessage(".*Standalone \\| Running.*", 1))
                 .withStartupTimeout(Duration.ofMillis(60000))
                 .withWorkingDirectory("/temp")
                 .waitingFor(Wait.forLogMessage(".*Running.*", 1));

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/ExistDb.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/ExistDb.java
@@ -25,13 +25,24 @@ import javax.management.ObjectName;
 /** Class to implement ExitDb */
 public class ExistDb implements ExistDbMXBean {
 
+    private final Map<QueryKey, RunningQuery> queries;
+
+    public ExistDb() {
+        queries = build();
+    }
+
     @Override
     public Map<QueryKey, RunningQuery> getRunningQueries() {
-        final Map<QueryKey, RunningQuery> queries = new TreeMap<>();
+        return queries;
+    }
 
-        final RunningQuery runningQuery1 =
+    private Map<QueryKey, RunningQuery> build() {
+        Map<QueryKey, RunningQuery> queries = new TreeMap<>();
+
+        RunningQuery runningQuery1 =
                 new RunningQuery(1, "/db/query1.xq", System.currentTimeMillis());
-        final RunningQuery runningQuery2 =
+
+        RunningQuery runningQuery2 =
                 new RunningQuery(2, "/db/query2.xq", System.currentTimeMillis());
 
         queries.put(new QueryKey(runningQuery1.getId(), runningQuery1.getPath()), runningQuery1);

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/ExistDbMXBean.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/ExistDbMXBean.java
@@ -30,6 +30,7 @@ public interface ExistDbMXBean {
 
     /** Class to implement QueryKey */
     class QueryKey implements Comparable<QueryKey> {
+
         private final int id;
         private final String path;
 

--- a/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/JmxExampleApplication.java
+++ b/integration_test_suite/jmx_example_application/src/main/java/io/prometheus/jmx/JmxExampleApplication.java
@@ -49,7 +49,7 @@ public class JmxExampleApplication {
                 LocalDateTime.now().format(DATE_TIME_FORMATTER),
                 Thread.currentThread().getName(),
                 JmxExampleApplication.class.getName(),
-                "Running");
+                "Running ...");
 
         Thread.currentThread().join();
     }


### PR DESCRIPTION
Fixed integration test startup timing issue where integration tests would begin before the test JmxApplication is completely running, resulting is integration test failures.