### PR TITLE
Fix standalone agent documentation URLs

### DIFF
--- a/docs/content/1.1.0/standalone/_index.md
+++ b/docs/content/1.1.0/standalone/_index.md
@@ -18,6 +18,6 @@ The Standalone JMX Exporter jar file is published via GitHub Releases.
 
 Installation depends on which modes you want to support:
 
-- [HTTP mode](/java-agent/http-mode/)
-- [OpenTelemetry mode](/java-agent/opentelemetry-mode/)
-- [Combined mode](/java-agent/combined-mode/)
+- [HTTP mode](./http-mode/)
+- [OpenTelemetry mode](./opentelemetry-mode/)
+- [Combined mode](./combined-mode/)

--- a/docs/content/1.2.0/standalone/_index.md
+++ b/docs/content/1.2.0/standalone/_index.md
@@ -18,6 +18,6 @@ The Standalone JMX Exporter jar file is published via GitHub Releases.
 
 Installation depends on which modes you want to support:
 
-- [HTTP mode](/java-agent/http-mode/)
-- [OpenTelemetry mode](/java-agent/opentelemetry-mode/)
-- [Combined mode](/java-agent/combined-mode/)
+- [HTTP mode](./http-mode/)
+- [OpenTelemetry mode](./opentelemetry-mode/)
+- [Combined mode](./combined-mode/)

--- a/docs/content/1.3.0/standalone/_index.md
+++ b/docs/content/1.3.0/standalone/_index.md
@@ -18,6 +18,6 @@ The Standalone JMX Exporter jar file is published via GitHub Releases.
 
 Installation depends on which modes you want to support:
 
-- [HTTP mode](/java-agent/http-mode/)
-- [OpenTelemetry mode](/java-agent/opentelemetry-mode/)
-- [Combined mode](/java-agent/combined-mode/)
+- [HTTP mode](./http-mode/)
+- [OpenTelemetry mode](./opentelemetry-mode/)
+- [Combined mode](./combined-mode/)

--- a/docs/content/1.4.0/standalone/_index.md
+++ b/docs/content/1.4.0/standalone/_index.md
@@ -18,6 +18,6 @@ The Standalone JMX Exporter jar file is published via GitHub Releases.
 
 Installation depends on which modes you want to support:
 
-- [HTTP mode](/java-agent/http-mode/)
-- [OpenTelemetry mode](/java-agent/opentelemetry-mode/)
-- [Combined mode](/java-agent/combined-mode/)
+- [HTTP mode](./http-mode/)
+- [OpenTelemetry mode](./opentelemetry-mode/)
+- [Combined mode](./combined-mode/)


### PR DESCRIPTION
Simple fix for the online documentation, fixing 404's when you try to go to any of the given pages on the standalone documentation.

@fstab