### PR TITLE
Updated test containers

### DIFF
--- a/integration_test_suite/integration_tests/src/test/resources/java-docker-images.txt
+++ b/integration_test_suite/integration_tests/src/test/resources/java-docker-images.txt
@@ -19,7 +19,7 @@ azul/zulu-openjdk:8
 azul/zulu-openjdk:11
 azul/zulu-openjdk:17
 azul/zulu-openjdk:21
-azul/zulu-openjdk:24
+azul/zulu-openjdk:25
 azul/prime:8
 azul/prime:11
 azul/prime:17


### PR DESCRIPTION
Removed azul/zulu-openjdk:24 from regression tests.
Added azul/zulu-openjdk:25 to regression tests.