### PR TITLE
Enable custom metrics path for HTTP server via configuration file

### DIFF
--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/metrics/path/MetricsPathConfigurationTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/metrics/path/MetricsPathConfigurationTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) The Prometheus jmx_exporter Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prometheus.jmx.test.http.metrics.path;
+
+import static io.prometheus.jmx.test.support.http.HttpResponse.assertHealthyResponse;
+import static io.prometheus.jmx.test.support.metrics.MetricAssertion.assertMetric;
+import static io.prometheus.jmx.test.support.metrics.MetricAssertion.assertMetricsContentType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.prometheus.jmx.test.support.environment.JmxExporterMode;
+import io.prometheus.jmx.test.support.environment.JmxExporterPath;
+import io.prometheus.jmx.test.support.environment.JmxExporterTestEnvironment;
+import io.prometheus.jmx.test.support.http.HttpClient;
+import io.prometheus.jmx.test.support.http.HttpHeader;
+import io.prometheus.jmx.test.support.http.HttpResponse;
+import io.prometheus.jmx.test.support.metrics.Metric;
+import io.prometheus.jmx.test.support.metrics.MetricsContentType;
+import io.prometheus.jmx.test.support.metrics.MetricsParser;
+import io.prometheus.jmx.test.support.util.TestSupport;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.paramixel.core.Action;
+import org.paramixel.core.ConsoleRunner;
+import org.paramixel.core.Paramixel;
+import org.paramixel.core.action.Direct;
+import org.paramixel.core.action.Lifecycle;
+import org.paramixel.core.action.Parallel;
+import org.paramixel.core.action.StrictSequential;
+import org.paramixel.core.support.Cleanup;
+import org.testcontainers.containers.Network;
+
+public class MetricsPathConfigurationTest {
+
+    private static class Attachment {
+        public Network network;
+        public JmxExporterTestEnvironment environment;
+
+        public Attachment() {}
+    }
+
+    public static void main(String[] args) {
+        ConsoleRunner.runAndExit(actionFactory());
+    }
+
+    @Paramixel.ActionFactory
+    public static Action actionFactory() {
+        return Parallel.of(
+                MetricsPathConfigurationTest.class.getName(),
+                JmxExporterTestEnvironment.createEnvironments()
+                        .map(MetricsPathConfigurationTest::createLifecycleAction)
+                        .toList());
+    }
+
+    private static Action createLifecycleAction(JmxExporterTestEnvironment environment) {
+        Action testHealthy = Direct.of("testHealthy", context -> {
+            var lifecycleContext = context.findContext(2).orElseThrow();
+            Attachment attachment = lifecycleContext
+                    .getAttachment()
+                    .flatMap(a -> a.to(Attachment.class))
+                    .orElseThrow();
+            String url = attachment.environment.getUrl(JmxExporterPath.HEALTHY);
+            HttpResponse httpResponse = HttpClient.sendRequest(url);
+            assertHealthyResponse(httpResponse);
+        });
+
+        Action testDefaultTextMetrics = Direct.of("testDefaultTextMetrics", context -> {
+            var lifecycleContext = context.findContext(2).orElseThrow();
+            Attachment attachment = lifecycleContext
+                    .getAttachment()
+                    .flatMap(a -> a.to(Attachment.class))
+                    .orElseThrow();
+            String url = attachment.environment.getUrl(JmxExporterPath.CUSTOM_METRICS);
+            HttpResponse httpResponse = HttpClient.sendRequest(url);
+            assertMetricsResponse(attachment.environment, httpResponse, MetricsContentType.DEFAULT);
+        });
+
+        Action testOpenMetricsTextMetrics = Direct.of("testOpenMetricsTextMetrics", context -> {
+            var lifecycleContext = context.findContext(2).orElseThrow();
+            Attachment attachment = lifecycleContext
+                    .getAttachment()
+                    .flatMap(a -> a.to(Attachment.class))
+                    .orElseThrow();
+            String url = attachment.environment.getUrl(JmxExporterPath.CUSTOM_METRICS);
+            HttpResponse httpResponse = HttpClient.sendRequest(
+                    url, HttpHeader.ACCEPT, MetricsContentType.OPEN_METRICS_TEXT_METRICS.toString());
+            assertMetricsResponse(attachment.environment, httpResponse, MetricsContentType.OPEN_METRICS_TEXT_METRICS);
+        });
+
+        Action testPrometheusTextMetrics = Direct.of("testPrometheusTextMetrics", context -> {
+            var lifecycleContext = context.findContext(2).orElseThrow();
+            Attachment attachment = lifecycleContext
+                    .getAttachment()
+                    .flatMap(a -> a.to(Attachment.class))
+                    .orElseThrow();
+            String url = attachment.environment.getUrl(JmxExporterPath.CUSTOM_METRICS);
+            HttpResponse httpResponse = HttpClient.sendRequest(
+                    url, HttpHeader.ACCEPT, MetricsContentType.PROMETHEUS_TEXT_METRICS.toString());
+            assertMetricsResponse(attachment.environment, httpResponse, MetricsContentType.PROMETHEUS_TEXT_METRICS);
+        });
+
+        Action testPrometheusProtobufMetrics = Direct.of("testPrometheusProtobufMetrics", context -> {
+            var lifecycleContext = context.findContext(2).orElseThrow();
+            Attachment attachment = lifecycleContext
+                    .getAttachment()
+                    .flatMap(a -> a.to(Attachment.class))
+                    .orElseThrow();
+            String url = attachment.environment.getUrl(JmxExporterPath.CUSTOM_METRICS);
+            HttpResponse httpResponse = HttpClient.sendRequest(
+                    url, HttpHeader.ACCEPT, MetricsContentType.PROMETHEUS_PROTOBUF_METRICS.toString());
+            assertMetricsResponse(attachment.environment, httpResponse, MetricsContentType.PROMETHEUS_PROTOBUF_METRICS);
+        });
+
+        Action tests = StrictSequential.of(
+                "tests",
+                List.of(
+                        testHealthy,
+                        testDefaultTextMetrics,
+                        testOpenMetricsTextMetrics,
+                        testPrometheusTextMetrics,
+                        testPrometheusProtobufMetrics));
+
+        return Lifecycle.of(
+                environment.getName(),
+                Direct.of("setUp", context -> {
+                    Network network = Network.newNetwork();
+                    network.getId();
+                    environment.initialize(MetricsPathConfigurationTest.class, network);
+                    Attachment attachment = new Attachment();
+                    attachment.network = network;
+                    attachment.environment = environment;
+                    context.setAttachment(attachment);
+                }),
+                tests,
+                Direct.of("tearDown", context -> {
+                    Attachment attachment = context.removeAttachment()
+                            .flatMap(a -> a.to(Attachment.class))
+                            .orElse(null);
+
+                    if (attachment != null) {
+                        Cleanup.of(Cleanup.Mode.FORWARD)
+                                .addCloseable(attachment.environment)
+                                .addCloseable(attachment.network)
+                                .runAndThrow();
+                    }
+                }));
+    }
+
+    private static void assertMetricsResponse(
+            JmxExporterTestEnvironment jmxExporterTestEnvironment,
+            HttpResponse httpResponse,
+            MetricsContentType metricsContentType) {
+        assertMetricsContentType(httpResponse, metricsContentType);
+
+        Map<String, Collection<Metric>> metrics = new LinkedHashMap<>();
+
+        Set<String> compositeNameSet = new HashSet<>();
+        MetricsParser.parseCollection(httpResponse).forEach(metric -> {
+            String name = metric.name();
+            Map<String, String> labels = metric.labels();
+            String compositeName = name + " " + labels;
+            assertThat(compositeNameSet).doesNotContain(compositeName);
+            compositeNameSet.add(compositeName);
+            metrics.computeIfAbsent(name, k -> new ArrayList<>()).add(metric);
+        });
+
+        boolean isJmxExporterModeJavaAgent =
+                jmxExporterTestEnvironment.getJmxExporterMode() == JmxExporterMode.JavaAgent;
+
+        String buildInfoName = TestSupport.getBuildInfoName(jmxExporterTestEnvironment.getJmxExporterMode());
+
+        assertMetric(metrics)
+                .ofType(Metric.Type.GAUGE)
+                .withName("jmx_exporter_build_info")
+                .withLabel("name", buildInfoName)
+                .withValue(1d)
+                .isPresent();
+
+        assertMetric(metrics)
+                .ofType(Metric.Type.GAUGE)
+                .withName("jmx_scrape_error")
+                .withValue(0d)
+                .isPresent();
+
+        assertMetric(metrics)
+                .ofType(Metric.Type.COUNTER)
+                .withName("jmx_config_reload_success_total")
+                .withValue(0d)
+                .isPresent();
+
+        assertMetric(metrics)
+                .ofType(Metric.Type.GAUGE)
+                .withName("jvm_memory_used_bytes")
+                .withLabel("area", "nonheap")
+                .isPresentWhen(isJmxExporterModeJavaAgent);
+
+        assertMetric(metrics)
+                .ofType(Metric.Type.GAUGE)
+                .withName("jvm_memory_used_bytes")
+                .withLabel("area", "heap")
+                .isPresentWhen(isJmxExporterModeJavaAgent);
+
+        assertMetric(metrics)
+                .ofType(Metric.Type.UNTYPED)
+                .withName("io_prometheus_jmx_test_PerformanceMetricsMBean_PerformanceMetrics_ActiveSessions")
+                .withValue(2.0d)
+                .isPresent();
+
+        assertMetric(metrics)
+                .ofType(Metric.Type.UNTYPED)
+                .withName("io_prometheus_jmx_test_PerformanceMetricsMBean_PerformanceMetrics_Bootstraps")
+                .withValue(4.0d)
+                .isPresent();
+
+        assertMetric(metrics)
+                .ofType(Metric.Type.UNTYPED)
+                .withName("io_prometheus_jmx_test_PerformanceMetricsMBean_PerformanceMetrics_BootstrapsDeferred")
+                .withValue(6.0d)
+                .isPresent();
+    }
+}

--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/metrics/path/__ConsolePackageRunner__.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/http/metrics/path/__ConsolePackageRunner__.java
@@ -14,32 +14,18 @@
  * limitations under the License.
  */
 
-package io.prometheus.jmx.test.support.environment;
+package io.prometheus.jmx.test.http.metrics.path;
 
-/**
- * Class to implement ExporterPath
- */
-public class JmxExporterPath {
+import org.paramixel.core.ConsoleRunner;
+import org.paramixel.core.discovery.Selector;
 
-    /**
-     * Healthy exporter path
-     */
-    public static final String HEALTHY = "/-/healthy";
+public class __ConsolePackageRunner__ {
 
-    /**
-     * Metrics exporter path
-     */
-    public static final String METRICS = "/metrics";
+    public static void main(String[] args) {
+        ConsoleRunner.runAndExit(selector());
+    }
 
-    /**
-     * Customize the metric exporter path from the YAML configuration file
-     */
-    public static final String CUSTOM_METRICS = "/custom/metrics";
-
-    /**
-     * Constructor
-     */
-    private JmxExporterPath() {
-        // INTENTIONALLY BLANK
+    private static Selector selector() {
+        return Selector.byPackageName(__ConsolePackageRunner__.class);
     }
 }

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/metrics/path/MetricsPathConfigurationTest/JavaAgent/application.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/metrics/path/MetricsPathConfigurationTest/JavaAgent/application.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+java \
+  -Xmx512M \
+  -javaagent:jmx_prometheus_javaagent.jar=8888:exporter.yaml \
+  -jar jmx_example_application.jar

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/metrics/path/MetricsPathConfigurationTest/JavaAgent/exporter.yaml
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/metrics/path/MetricsPathConfigurationTest/JavaAgent/exporter.yaml
@@ -1,0 +1,5 @@
+httpServer:
+  metrics:
+    path: /custom/metrics
+rules:
+  - pattern: ".*"

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/metrics/path/MetricsPathConfigurationTest/Standalone/application.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/metrics/path/MetricsPathConfigurationTest/Standalone/application.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+java \
+  -Xmx512M \
+  -Dcom.sun.management.jmxremote=true \
+  -Dcom.sun.management.jmxremote.authenticate=false \
+  -Dcom.sun.management.jmxremote.local.only=false \
+  -Dcom.sun.management.jmxremote.port=9999 \
+  -Dcom.sun.management.jmxremote.registry.ssl=false \
+  -Dcom.sun.management.jmxremote.rmi.port=9999 \
+  -Dcom.sun.management.jmxremote.ssl.need.client.auth=false \
+  -Dcom.sun.management.jmxremote.ssl=false \
+  -jar jmx_example_application.jar

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/metrics/path/MetricsPathConfigurationTest/Standalone/exporter.sh
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/metrics/path/MetricsPathConfigurationTest/Standalone/exporter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+java \
+  -Xmx512M \
+  -jar jmx_prometheus_standalone.jar 8888 exporter.yaml

--- a/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/metrics/path/MetricsPathConfigurationTest/Standalone/exporter.yaml
+++ b/integration_test_suite/integration_tests/src/test/resources/io/prometheus/jmx/test/http/metrics/path/MetricsPathConfigurationTest/Standalone/exporter.yaml
@@ -1,0 +1,6 @@
+httpServer:
+  metrics:
+    path: /custom/metrics
+hostPort: application:9999
+rules:
+  - pattern: ".*"

--- a/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/HTTPServerFactory.java
+++ b/jmx_prometheus_common/src/main/java/io/prometheus/jmx/common/HTTPServerFactory.java
@@ -299,6 +299,7 @@ public class HTTPServerFactory {
         HTTPServer.Builder httpServerBuilder =
                 HTTPServer.builder().inetAddress(inetAddress).port(port).registry(prometheusRegistry);
 
+        configureMetricsPath(rootMapAccessor, httpServerBuilder);
         configureThreads(rootMapAccessor, httpServerBuilder);
         configureAuthentication(authenticationConfiguration, httpServerBuilder);
         configureSSL(rootMapAccessor, httpServerBuilder);
@@ -329,6 +330,7 @@ public class HTTPServerFactory {
 
         HTTPServer.Builder httpServerBuilder = HTTPServer.builder().registry(prometheusRegistry);
 
+        configureMetricsPath(rootMapAccessor, httpServerBuilder);
         configureThreads(rootMapAccessor, httpServerBuilder);
         configureAuthentication(authenticationConfiguration, httpServerBuilder);
         configureSSL(rootMapAccessor, httpServerBuilder);
@@ -336,6 +338,38 @@ public class HTTPServerFactory {
         HTTPServer httpServer = httpServerBuilder.buildAndStart();
         configureSecurityHeaders(httpServer, prometheusRegistry, authenticationConfiguration, sslEnabled);
         return httpServer;
+    }
+
+    /**
+     * Configures the HTTP server metrics path based on YAML configuration.
+     *
+     * <p>Metrics path configuration is read from the {@code /httpServer/metrics} path. If not
+     * specified, default values are used: {@code path =} {@value #METRICS_PATH}
+     *
+     * @param rootMapAccessor the root configuration map accessor, must not be {@code null}
+     * @param httpServerBuilder the HTTP server builder to configure, must not be {@code null}
+     * @throws ConfigurationException if the metrics path configuration is invalid
+     */
+    private static void configureMetricsPath(MapAccessor rootMapAccessor, HTTPServer.Builder httpServerBuilder) {
+        String metricsPath = METRICS_PATH;
+
+        if (rootMapAccessor.containsPath("/httpServer/metrics")) {
+            MapAccessor httpServerMetricsMapAccessor = rootMapAccessor
+                    .get("/httpServer/metrics")
+                    .map(new ToMapAccessor(ConfigurationException.supplier(
+                            "Invalid configuration for /httpServer/metrics" + " must be a map")))
+                    .orElseThrow(ConfigurationException.supplier("/httpServer/metrics must be a map"));
+
+            metricsPath = httpServerMetricsMapAccessor
+                    .get("/path")
+                    .map(new ToString(ConfigurationException.supplier(
+                            "Invalid configuration for" + " /httpServer/metrics/path" + " must be a string")))
+                    .map(new StringIsNotBlank(ConfigurationException.supplier(
+                            "Invalid configuration for" + " /httpServer/metrics/path" + " must not be blank")))
+                    .orElseThrow(ConfigurationException.supplier("/httpServer/metrics/path is a" + " required string"));
+        }
+
+        httpServerBuilder.metricsHandlerPath(metricsPath);
     }
 
     /**

--- a/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/util/MapAccessorTest.java
+++ b/jmx_prometheus_common/src/test/java/io/prometheus/jmx/common/util/MapAccessorTest.java
@@ -88,6 +88,16 @@ public class MapAccessorTest {
                     .isEqualTo("c6d52fc2733af33e62b45d4525261e35e04f7b0ec227e4feee8fd3fe1401a2a9");
         });
 
+        optional = mapAccessor.get("/httpServer/metrics");
+        assertThat(optional).isNotNull().hasValueSatisfying(value -> {
+            assertThat(value).isNotNull().isInstanceOf(Map.class);
+        });
+
+        optional = mapAccessor.get("/httpServer/metrics/path");
+        assertThat(optional).isNotNull().hasValueSatisfying(value -> {
+            assertThat(value).isNotNull().isInstanceOf(String.class).isEqualTo("/custom/metrics");
+        });
+
         optional = mapAccessor.get("/httpServer/threads");
         assertThat(optional).isNotNull().hasValueSatisfying(value -> {
             assertThat(value).isNotNull().isInstanceOf(Map.class);

--- a/jmx_prometheus_common/src/test/resources/MapAccessorTest.yaml
+++ b/jmx_prometheus_common/src/test/resources/MapAccessorTest.yaml
@@ -7,6 +7,8 @@ httpServer:
       salt: PvrLg8tJphqTM8286VfH2w==
       iterations: 1000
       keyLength: 256
+  metrics:
+    path: /custom/metrics
   ssl:
     certificate:
       alias: localhost


### PR DESCRIPTION
- Add `configureMetricsPath()` to read custom metrics export path
  from the YAML configuration file.
  e.g.:
  ```yaml
  httpServer:
    metrics:
      path: /custom/metrics/path
  ```

- Update relevant tests to ensure the feature functions correctly.


Related PR: https://github.com/prometheus/client_java/pull/1735