### PR TITLE
ci: pin contents: read on build and manual-build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,9 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -1,5 +1,8 @@
 name: Manual Build
 on: [workflow_dispatch]
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Adds an explicit top-level `permissions: contents: read` block to the two CI workflows still inheriting org defaults. Both only run `./run-quick-test.sh` / `./mvnw clean install` against a Java toolchain checkout.