### PR TITLE
fix: Added defensive copy

### DIFF
--- a/collector/src/main/java/io/prometheus/jmx/MatchedRulesCache.java
+++ b/collector/src/main/java/io/prometheus/jmx/MatchedRulesCache.java
@@ -134,10 +134,10 @@ public class MatchedRulesCache {
         public CacheKey(
                 String domain, LinkedHashMap<String, String> beanProperties, List<String> attrKeys, String attrName) {
             this.domain = domain;
-            this.beanProperties = beanProperties;
-            this.attrKeys = attrKeys;
+            this.beanProperties = new LinkedHashMap<>(beanProperties);
+            this.attrKeys = new ArrayList<>(attrKeys);
             this.attrName = attrName;
-            this.cachedHashCode = Objects.hash(domain, beanProperties, attrKeys, attrName);
+            this.cachedHashCode = Objects.hash(domain, this.beanProperties, this.attrKeys, attrName);
         }
 
         @Override


### PR DESCRIPTION
 The CacheKey constructor stored beanProperties (LinkedHashMap) and attrKeys (List) by reference. Since these are mutable, external code could modify them after the key was used in a HashMap, causing hashCode() to become inconsistent with equals()