### PR TITLE
fix: Reverted Caffeine version to maintain Java 8 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <!-- Dependency versions -->
         <assertj.version>3.27.7</assertj.version>
         <ayza.version>10.0.5</ayza.version>
-        <caffeine.version>3.2.4</caffeine.version>
+        <caffeine.version>2.9.3</caffeine.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <junit.version>6.1.0</junit.version>
         <logback.version>1.5.34</logback.version>

--- a/renovate.json
+++ b/renovate.json
@@ -1,34 +1,43 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "dependencyDashboard": false,
-  "packageRules": [
-    {
-      "matchManagers": [
-        "maven-wrapper"
-      ],
-      "allowedVersions": "3.9.6",
-      "groupName": "Maven wrapper pinned to 3.9.6"
-    },
-    {
-      "description": "Do not try to resolve internal Maven reactor modules from Maven repositories",
-      "matchManagers": [
-        "maven"
-      ],
-      "matchPackageNames": [
-        "io.prometheus.jmx:integration_test_suite",
-        "io.prometheus.jmx:jmx_example_application"
-      ],
-      "enabled": false
-    },
-    {
-      "matchManagers": [
-        "maven"
-      ],
-      "groupName": "Maven dependencies"
-    }
-  ]
+ "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+ "extends": [
+ "config:recommended"
+ ],
+ "dependencyDashboard": false,
+ "packageRules": [
+ {
+ "matchManagers": [
+ "maven-wrapper"
+ ],
+ "allowedVersions": "3.9.6",
+ "groupName": "Maven wrapper pinned to3.9.6"
+ },
+ {
+ "description": "Do not try to resolve internal Maven reactor modules from Maven repositories",
+ "matchManagers": [
+ "maven"
+ ],
+ "matchPackageNames": [
+ "io.prometheus.jmx:integration_test_suite",
+ "io.prometheus.jmx:jmx_example_application"
+ ],
+ "enabled": false
+ },
+ {
+ "matchManagers": [
+ "maven"
+ ],
+ "matchPackageNames": [
+ "com.github.ben-manes.caffeine:caffeine"
+ ],
+ "allowedVersions": "2.9.3",
+ "description": "Pin Caffeine to2.9.3;3.x is a major API change requiring migration"
+ },
+ {
+ "matchManagers": [
+ "maven"
+ ],
+ "groupName": "Maven dependencies"
+ }
+ ]
 }
-


### PR DESCRIPTION
- Reverted Caffeine version to maintain Java 8 compatibility.
- Changed version-rules.xml to pin Caffeine version
- Change renovate.json to pin Caffeine version