### PR TITLE
fix: Fixed integration test

### DIFF
--- a/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/opentelemetry/CombinedModeWithSSLTest.java
+++ b/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/opentelemetry/CombinedModeWithSSLTest.java
@@ -42,6 +42,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.paramixel.api.Paramixel;
 import org.paramixel.api.Runner;
 import org.paramixel.api.action.Action;
@@ -68,9 +69,14 @@ public class CombinedModeWithSSLTest {
 
     @Paramixel.Factory
     public static Action factory() throws Throwable {
+        var environments = OpenTelemetryTestEnvironment.createTestEnvironments(CombinedModeWithSSLTest.class).stream()
+                .filter(env ->
+                        !env.exporterTestEnvironment().getJavaDockerImage().contains("eclipse-temurin:8-alpine"))
+                .collect(Collectors.toList());
+
         return Each.parallel(
                         CombinedModeWithSSLTest.class.getName(),
-                        OpenTelemetryTestEnvironment.createTestEnvironments(CombinedModeWithSSLTest.class),
+                        environments,
                         environment -> Instance.builder(
                                         environment.exporterTestEnvironment().name(),
                                         () -> new CombinedModeWithSSLTest(environment))


### PR DESCRIPTION
- Fixed integration test to correctly filter eclipse-temurin:8-alpine due to SSL related issues for the Java distribution
  - Consistent with other SSL related tests