### PR TITLE
fix: check for null when MBeanInfo is incomplete

### DIFF
--- a/.github/workflows/approve-workflows.yml
+++ b/.github/workflows/approve-workflows.yml
@@ -15,13 +15,13 @@ jobs:
     if: >-
       github.event.issue.pull_request &&
       github.event.comment.body == '/workflow-approve' &&
-      github.repository_owner == 'prometheus'
+      (github.repository_owner == 'prometheus' || github.repository_owner == 'prometheus-community')
     runs-on: ubuntu-latest
     permissions:
       actions: write
       contents: read
       pull-requests: write
     steps:
-      - uses: prometheus/promci/approve_workflows@370e8c15dcec50043cbe66f2f34633d9efc0a190
+      - uses: prometheus/promci/approve_workflows@370e8c15dcec50043cbe66f2f34633d9efc0a190 # v0.9.0
         with:
           github_token: ${{ github.token }}

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -416,7 +416,9 @@ class JmxScraper {
 
                 MBeanAttributeInfo mBeanAttributeInfo = name2MBeanAttributeInfo.get(attributeName);
                 if (mBeanAttributeInfo == null) {
-                    LOGGER.trace("%s returned attribute '%s' that is not present in its MBeanInfo. Skipping.", mBeanName, attributeName);
+                    LOGGER.trace(
+                            "%s returned attribute '%s' that is not present in its MBeanInfo. Skipping.",
+                            mBeanName, attributeName);
                     continue;
                 }
                 LOGGER.trace("%s_%s process", mBeanName, mBeanAttributeInfo.getName());

--- a/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
+++ b/collector/src/main/java/io/prometheus/jmx/JmxScraper.java
@@ -415,6 +415,10 @@ class JmxScraper {
                 }
 
                 MBeanAttributeInfo mBeanAttributeInfo = name2MBeanAttributeInfo.get(attributeName);
+                if (mBeanAttributeInfo == null) {
+                    LOGGER.trace("%s returned attribute '%s' that is not present in its MBeanInfo. Skipping.", mBeanName, attributeName);
+                    continue;
+                }
                 LOGGER.trace("%s_%s process", mBeanName, mBeanAttributeInfo.getName());
                 processBeanValue(
                         mBeanName,


### PR DESCRIPTION
If the MBeanInfo is incomplete / invalid, a null pointer exception can occur, aborting the entire loop.

@dhoard 
@fstab 