### PR TITLE
fix: Fixed release.sh

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,7 +43,7 @@
    - Signs each jar with GPG
    - Generates SHA256 checksums
 9. Commits release on release branch
-10. Creates annotated tag: `v{VERSION}`
+10. Creates annotated tag: `{VERSION}`
 11. Pushes release branch and tag to remote
 12. Switches back to main branch
 13. Sets post-release version: `{VERSION}-POST`

--- a/release.sh
+++ b/release.sh
@@ -181,7 +181,7 @@ check_git_state() {
 check_no_existing_release() {
     local ver="$1"
     local release_branch="release-${ver}"
-    local tag_name="v${ver}"
+    local tag_name="${ver}"
     
     log_info "Checking for existing release"
     
@@ -306,7 +306,7 @@ commit_release() {
 
 tag_release() {
     local ver="$1"
-    local tag_name="v${ver}"
+    local tag_name="${ver}"
     
     log_info "Creating git tag"
     
@@ -318,7 +318,7 @@ tag_release() {
 push_release() {
     local ver="$1"
     local release_branch="release-${ver}"
-    local tag_name="v${ver}"
+    local tag_name="${ver}"
     
     log_info "Pushing release to remote"
     
@@ -408,7 +408,7 @@ main() {
     log_info "This will:"
     log_info "  - Create branch: release-${version}"
     log_info "  - Build and deploy to Maven Central"
-    log_info "  - Create git tag: v${version}"
+    log_info "  - Create git tag: ${version}"
     log_info "  - Push to remote: ${git_remote}"
     log_info "  - Sign artifacts with GPG key: ${gpg_key_id:-default}"
     echo ""


### PR DESCRIPTION
Fixed release.sh to correctly not include `v` in a release tag