### PR TITLE
feat: add graceful startup error handling to Java agent

### DIFF
--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/Arguments.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/Arguments.java
@@ -56,6 +56,11 @@ public class Arguments {
     private static final String DEFAULT_HOST = "0.0.0.0";
 
     /**
+     * Prefix that enables graceful error handling for startup errors.
+     */
+    private static final String GRACEFUL_PREFIX = "graceful:";
+
+    /**
      * Regular expression pattern for parsing agent arguments.
      *
      * <p>Captures groups:
@@ -103,6 +108,15 @@ public class Arguments {
     private final String filename;
 
     /**
+     * Flag indicating whether graceful error handling is enabled.
+     *
+     * <p>When {@code true}, startup errors are logged and resources are cleaned up without calling
+     * {@code System.exit(1)}. When {@code false}, the agent fails fast and exits the JVM on startup
+     * errors.
+     */
+    private final boolean gracefulErrorHandling;
+
+    /**
      * Constructs an Arguments instance with the specified configuration.
      *
      * @param httpEnabled whether the HTTP server is enabled
@@ -110,13 +124,15 @@ public class Arguments {
      *     disabled
      * @param port the port number for HTTP server, may be {@code null} when HTTP is disabled
      * @param filename the path to the configuration file, must not be {@code null}
+     * @param gracefulErrorHandling whether graceful error handling is enabled
      * @throws NullPointerException if {@code filename} is {@code null}
      */
-    private Arguments(boolean httpEnabled, String host, Integer port, String filename) {
+    private Arguments(boolean httpEnabled, String host, Integer port, String filename, boolean gracefulErrorHandling) {
         this.httpEnabled = httpEnabled;
         this.host = host;
         this.port = port;
         this.filename = Objects.requireNonNull(filename, "filename cannot be null");
+        this.gracefulErrorHandling = gracefulErrorHandling;
     }
 
     /**
@@ -170,6 +186,18 @@ public class Arguments {
     }
 
     /**
+     * Returns whether graceful error handling is enabled.
+     *
+     * <p>When {@code true}, startup errors are logged and resources are cleaned up without calling
+     * {@code System.exit(1)}.
+     *
+     * @return {@code true} if graceful error handling is enabled, {@code false} otherwise
+     */
+    public boolean isGracefulErrorHandling() {
+        return gracefulErrorHandling;
+    }
+
+    /**
      * Parses the Java agent argument string into an Arguments instance.
      *
      * <p>Supports the following argument formats:
@@ -178,6 +206,9 @@ public class Arguments {
      *   <li>{@code port:configFile} - Enables HTTP on default host (0.0.0.0) and specified port
      *   <li>{@code host:port:configFile} - Enables HTTP on specified host and port
      *   <li>{@code configFile} - Disables HTTP (only OpenTelemetry export possible via config)
+     *   <li>{@code graceful:port:configFile} - Enables HTTP and graceful error handling
+     *   <li>{@code graceful:host:port:configFile} - Enables HTTP on specified host/port and graceful error handling
+     *   <li>{@code graceful:configFile} - Disables HTTP and enables graceful error handling
      * </ul>
      *
      * <p>Host can be a hostname, IPv4 address, or IPv6 address enclosed in square brackets.
@@ -191,13 +222,63 @@ public class Arguments {
             throw new ConfigurationException(format("Malformed arguments [%s]", agentArgument));
         }
 
-        Pattern pattern = Pattern.compile(CONFIGURATION_REGEX);
-        Matcher matcher = pattern.matcher(agentArgument);
+        boolean gracefulErrorHandling = parseGracefulPrefix(agentArgument);
+        String remainingArgument = stripGracefulPrefix(agentArgument);
 
+        ParsedHttpArguments parsedHttpArguments = parseHttpArguments(remainingArgument);
+
+        return new Arguments(
+                parsedHttpArguments.httpEnabled,
+                parsedHttpArguments.host,
+                parsedHttpArguments.port,
+                parsedHttpArguments.filename,
+                gracefulErrorHandling);
+    }
+
+    /**
+     * Determines whether the agent argument starts with the graceful error handling prefix.
+     *
+     * @param agentArgument the agent argument string to check, must not be {@code null}
+     * @return {@code true} if the argument starts with {@code graceful:}, {@code false} otherwise
+     */
+    private static boolean parseGracefulPrefix(String agentArgument) {
+        return agentArgument.startsWith(GRACEFUL_PREFIX);
+    }
+
+    /**
+     * Strips the optional graceful error handling prefix from the agent argument.
+     *
+     * @param agentArgument the agent argument string, must not be {@code null}
+     * @return the argument string with the graceful prefix removed, if present
+     * @throws ConfigurationException if only the graceful prefix was provided
+     */
+    private static String stripGracefulPrefix(String agentArgument) {
+        if (agentArgument.startsWith(GRACEFUL_PREFIX)) {
+            String remaining = agentArgument.substring(GRACEFUL_PREFIX.length());
+            if (remaining.isEmpty()) {
+                throw new ConfigurationException(format("Malformed arguments [%s]", remaining));
+            }
+            return remaining;
+        }
+        return agentArgument;
+    }
+
+    /**
+     * Parses the host, port, and filename from the agent argument after any graceful prefix has been
+     * removed.
+     *
+     * @param agentArgument the agent argument string with graceful prefix already stripped
+     * @return a {@link ParsedHttpArguments} containing the parsed values
+     * @throws ConfigurationException if the argument is malformed
+     */
+    private static ParsedHttpArguments parseHttpArguments(String agentArgument) {
         boolean httpEnabled = false;
         String host = null;
         Integer port = null;
         String filename;
+
+        Pattern pattern = Pattern.compile(CONFIGURATION_REGEX);
+        Matcher matcher = pattern.matcher(agentArgument);
 
         if (matcher.matches()) {
             httpEnabled = true;
@@ -225,6 +306,24 @@ public class Arguments {
             filename = agentArgument;
         }
 
-        return new Arguments(httpEnabled, host, port, filename);
+        return new ParsedHttpArguments(httpEnabled, host, port, filename);
+    }
+
+    /**
+     * Simple holder for HTTP-related parsed arguments.
+     */
+    private static class ParsedHttpArguments {
+
+        final boolean httpEnabled;
+        final String host;
+        final Integer port;
+        final String filename;
+
+        ParsedHttpArguments(boolean httpEnabled, String host, Integer port, String filename) {
+            this.httpEnabled = httpEnabled;
+            this.host = host;
+            this.port = port;
+            this.filename = filename;
+        }
     }
 }

--- a/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
+++ b/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.lang.instrument.Instrumentation;
 import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
+import java.util.function.IntConsumer;
 
 /**
  * Java agent for the Prometheus JMX exporter.
@@ -128,8 +129,15 @@ public class JavaAgent {
      *     invalid
      */
     public static void premain(String agentArgument, Instrumentation instrumentation) {
+        Arguments arguments;
         try {
-            Arguments arguments = Arguments.parse(agentArgument);
+            arguments = Arguments.parse(agentArgument);
+        } catch (Throwable t) {
+            handleError(t, null, null, false);
+            return;
+        }
+
+        try {
             File file = new File(arguments.getFilename());
             MapAccessor mapAccessor = MapAccessor.of(YamlSupport.loadYaml(file));
 
@@ -149,7 +157,7 @@ public class JavaAgent {
                 start(arguments, file, mapAccessor);
             }
         } catch (Throwable t) {
-            handleError(t, null, null);
+            handleError(t, null, null, arguments.isGracefulErrorHandling());
         }
     }
 
@@ -174,6 +182,7 @@ public class JavaAgent {
      *     {@code null}
      */
     private static void startAsync(int startDelaySeconds, Arguments arguments, File file, MapAccessor mapAccessor) {
+        boolean gracefulErrorHandling = arguments.isGracefulErrorHandling();
         Thread thread = new Thread(
                 () -> {
                     try {
@@ -183,7 +192,7 @@ public class JavaAgent {
                         Thread.currentThread().interrupt();
                         LOGGER.warn("Startup delay of %d seconds interrupted", startDelaySeconds);
                     } catch (Throwable t) {
-                        handleError(t, null, null);
+                        handleError(t, null, null, gracefulErrorHandling);
                     }
                 },
                 THREAD_NAME);
@@ -249,7 +258,7 @@ public class JavaAgent {
 
             LOGGER.info("Running ...");
         } catch (Throwable t) {
-            handleError(t, openTelemetryExporter, httpServer);
+            handleError(t, openTelemetryExporter, httpServer, arguments.isGracefulErrorHandling());
         }
     }
 
@@ -306,36 +315,64 @@ public class JavaAgent {
     }
 
     /**
-     * Handles a startup failure by logging the error and cleaning up resources.
+     * Handles a startup failure by logging the error, cleaning up resources, and optionally exiting
+     * the JVM.
      *
-     * <p>This method:
-     *
-     * <ul>
-     *   <li>Prints the error stack trace to stderr (synchronized to prevent interleaving)
-     *   <li>Closes any started resources (OpenTelemetry exporter, HTTP server)
-     *   <li>Exits the JVM with status code 1
-     * </ul>
-     *
-     * <p>This method never returns; it always calls {@code System.exit(1)}.
+     * <p>When {@code gracefulErrorHandling} is {@code false}, this method prints the error, closes
+     * resources, and calls {@code System.exit(1)}. When {@code gracefulErrorHandling} is {@code
+     * true}, it prints the error and closes resources but does not exit the JVM.
      *
      * @param t the throwable that caused the failure, may be {@code null}
      * @param openTelemetryExporter the OpenTelemetry exporter to close, may be {@code null}
      * @param httpServer the HTTP server to close, may be {@code null}
+     * @param gracefulErrorHandling whether to skip the JVM exit
      */
-    private static void handleError(Throwable t, OpenTelemetryExporter openTelemetryExporter, HTTPServer httpServer) {
+    private static void handleError(
+            Throwable t,
+            OpenTelemetryExporter openTelemetryExporter,
+            HTTPServer httpServer,
+            boolean gracefulErrorHandling) {
+        handleError(t, openTelemetryExporter, httpServer, gracefulErrorHandling, System::exit);
+    }
+
+    /**
+     * Handles a startup failure by logging the error, cleaning up resources, and optionally exiting
+     * the JVM.
+     *
+     * <p>This overload allows tests to inject an exit action instead of calling {@link
+     * System#exit(int)}.
+     *
+     * @param t the throwable that caused the failure, may be {@code null}
+     * @param openTelemetryExporter the OpenTelemetry exporter to close, may be {@code null}
+     * @param httpServer the HTTP server to close, may be {@code null}
+     * @param gracefulErrorHandling if {@code true}, log and clean up without exiting the JVM
+     * @param exit the exit action to invoke when not in graceful mode
+     */
+    static void handleError(
+            Throwable t,
+            OpenTelemetryExporter openTelemetryExporter,
+            HTTPServer httpServer,
+            boolean gracefulErrorHandling,
+            IntConsumer exit) {
         synchronized (System.err) {
             System.err.println("Failed to start Prometheus JMX Exporter ...");
             System.err.println();
             t.printStackTrace(System.err);
             System.err.println();
-            System.err.println("Prometheus JMX Exporter exiting");
+            if (gracefulErrorHandling) {
+                System.err.println("Prometheus JMX Exporter continuing in graceful error handling mode");
+            } else {
+                System.err.println("Prometheus JMX Exporter exiting");
+            }
             System.err.flush();
         }
 
         close(openTelemetryExporter);
         close(httpServer);
 
-        System.exit(1);
+        if (!gracefulErrorHandling) {
+            exit.accept(1);
+        }
     }
 
     /**

--- a/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/ArgumentsTest.java
+++ b/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/ArgumentsTest.java
@@ -62,6 +62,16 @@ public class ArgumentsTest {
     private static final boolean INVALID_CONFIGURATION = false;
 
     /**
+     * Constant for graceful error handling enabled state in test definitions.
+     */
+    private static final boolean GRACEFUL_ENABLED = true;
+
+    /**
+     * Constant for graceful error handling disabled state in test definitions.
+     */
+    private static final boolean GRACEFUL_DISABLED = false;
+
+    /**
      * Test data array containing various valid and invalid argument configurations.
      */
     private static final ArgumentsTestDefinition[] ARGUMENTS_TEST_DEFINITIONS = {
@@ -71,35 +81,40 @@ public class ArgumentsTest {
                 HTTP_ENABLED,
                 "0.0.0.0",
                 12345,
-                "/opt/prometheus/config.yaml"),
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "12345:/opt/prometheus/config_file.yaml",
                 HTTP_ENABLED,
                 "0.0.0.0",
                 12345,
-                "/opt/prometheus/config_file.yaml"),
+                "/opt/prometheus/config_file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "12345:/opt/prometheus/config-file.yaml",
                 HTTP_ENABLED,
                 "0.0.0.0",
                 12345,
-                "/opt/prometheus/config-file.yaml"),
+                "/opt/prometheus/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "12345:/opt/prometheus/jmx-exporter/config-file.yaml",
                 HTTP_ENABLED,
                 "0.0.0.0",
                 12345,
-                "/opt/prometheus/jmx-exporter/config-file.yaml"),
+                "/opt/prometheus/jmx-exporter/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "12345:/opt/prometheus/jmx_exporter/config-file.yaml",
                 HTTP_ENABLED,
                 "0.0.0.0",
                 12345,
-                "/opt/prometheus/jmx_exporter/config-file.yaml"),
+                "/opt/prometheus/jmx_exporter/config-file.yaml",
+                GRACEFUL_DISABLED),
         // Regression: port:file format was previously handled by a dead
         // switch (matcher.groupCount()) case 2 branch that never executed
         // because groupCount() always returns 3, matching only by accident
@@ -110,268 +125,368 @@ public class ArgumentsTest {
                 HTTP_ENABLED,
                 "0.0.0.0",
                 65535,
-                "/opt/prometheus/config.yaml"),
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "myhost.domain.com:12345:/opt/prometheus/config.yaml",
                 HTTP_ENABLED,
                 "myhost.domain.com",
                 12345,
-                "/opt/prometheus/config.yaml"),
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "myhost.domain.com:12345:/opt/prometheus/config_file.yaml",
                 HTTP_ENABLED,
                 "myhost.domain.com",
                 12345,
-                "/opt/prometheus/config_file.yaml"),
+                "/opt/prometheus/config_file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "myhost.domain.com:12345:/opt/prometheus/config-file.yaml",
                 HTTP_ENABLED,
                 "myhost.domain.com",
                 12345,
-                "/opt/prometheus/config-file.yaml"),
+                "/opt/prometheus/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "myhost.domain.com:12345:/opt/prometheus/jmx-exporter/config-file.yaml",
                 HTTP_ENABLED,
                 "myhost.domain.com",
                 12345,
-                "/opt/prometheus/jmx-exporter/config-file.yaml"),
+                "/opt/prometheus/jmx-exporter/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "myhost.domain.com:12345:/opt/prometheus/jmx_exporter/config-file.yaml",
                 HTTP_ENABLED,
                 "myhost.domain.com",
                 12345,
-                "/opt/prometheus/jmx_exporter/config-file.yaml"),
+                "/opt/prometheus/jmx_exporter/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "myhostname.sub-domain.prometheus.org:12345:/opt/prometheus/config.yaml",
                 HTTP_ENABLED,
                 "myhostname.sub-domain.prometheus.org",
                 12345,
-                "/opt/prometheus/config.yaml"),
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "myhostname.sub-domain.prometheus.org:12345:/opt/prometheus/config_file.yaml",
                 HTTP_ENABLED,
                 "myhostname.sub-domain.prometheus.org",
                 12345,
-                "/opt/prometheus/config_file.yaml"),
+                "/opt/prometheus/config_file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "myhostname.sub-domain.prometheus.org:12345:/opt/prometheus/config-file.yaml",
                 HTTP_ENABLED,
                 "myhostname.sub-domain.prometheus.org",
                 12345,
-                "/opt/prometheus/config-file.yaml"),
+                "/opt/prometheus/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "127.0.0.1:12345:/opt/prometheus/config.yaml",
                 HTTP_ENABLED,
                 "127.0.0.1",
                 12345,
-                "/opt/prometheus/config.yaml"),
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "127.0.0.1:12345:/opt/prometheus/config_file.yaml",
                 HTTP_ENABLED,
                 "127.0.0.1",
                 12345,
-                "/opt/prometheus/config_file.yaml"),
+                "/opt/prometheus/config_file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "127.0.0.1:12345:/opt/prometheus/config-file.yaml",
                 HTTP_ENABLED,
                 "127.0.0.1",
                 12345,
-                "/opt/prometheus/config-file.yaml"),
+                "/opt/prometheus/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[::]:12345:/opt/prometheus/config.yaml",
                 HTTP_ENABLED,
                 "::",
                 12345,
-                "/opt/prometheus/config.yaml"),
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[::]:12345:/opt/prometheus/config_file.yaml",
                 HTTP_ENABLED,
                 "::",
                 12345,
-                "/opt/prometheus/config_file.yaml"),
+                "/opt/prometheus/config_file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[::]:12345:/opt/prometheus/config-file.yaml",
                 HTTP_ENABLED,
                 "::",
                 12345,
-                "/opt/prometheus/config-file.yaml"),
+                "/opt/prometheus/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[::1]:12345:/opt/prometheus/config.yaml",
                 HTTP_ENABLED,
                 "::1",
                 12345,
-                "/opt/prometheus/config.yaml"),
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[::1]:12345:/opt/prometheus/config_file.yaml",
                 HTTP_ENABLED,
                 "::1",
                 12345,
-                "/opt/prometheus/config_file.yaml"),
+                "/opt/prometheus/config_file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[::1]:12345:/opt/prometheus/config-file.yaml",
                 HTTP_ENABLED,
                 "::1",
                 12345,
-                "/opt/prometheus/config-file.yaml"),
+                "/opt/prometheus/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[::ffff:192.168.1.1]:12345:/opt/prometheus/config.yaml",
                 HTTP_ENABLED,
                 "::ffff:192.168.1.1",
                 12345,
-                "/opt/prometheus/config.yaml"),
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[::ffff:192.168.1.1]:12345:/opt/prometheus/config_file.yaml",
                 HTTP_ENABLED,
                 "::ffff:192.168.1.1",
                 12345,
-                "/opt/prometheus/config_file.yaml"),
+                "/opt/prometheus/config_file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[::ffff:192.168.1.1]:12345:/opt/prometheus/config-file.yaml",
                 HTTP_ENABLED,
                 "::ffff:192.168.1.1",
                 12345,
-                "/opt/prometheus/config-file.yaml"),
+                "/opt/prometheus/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[fe80::1]:12345:/opt/prometheus/config.yaml",
                 HTTP_ENABLED,
                 "fe80::1",
                 12345,
-                "/opt/prometheus/config.yaml"),
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[fe80::1]:12345:/opt/prometheus/config_file.yaml",
                 HTTP_ENABLED,
                 "fe80::1",
                 12345,
-                "/opt/prometheus/config_file.yaml"),
+                "/opt/prometheus/config_file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[fe80::1]:12345:/opt/prometheus/config-file.yaml",
                 HTTP_ENABLED,
                 "fe80::1",
                 12345,
-                "/opt/prometheus/config-file.yaml"),
+                "/opt/prometheus/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[2001:db8::1]:12345:/opt/prometheus/config.yaml",
                 HTTP_ENABLED,
                 "2001:db8::1",
                 12345,
-                "/opt/prometheus/config.yaml"),
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[2001:db8::1]:12345:/opt/prometheus/config_file.yaml",
                 HTTP_ENABLED,
                 "2001:db8::1",
                 12345,
-                "/opt/prometheus/config_file.yaml"),
+                "/opt/prometheus/config_file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[2001:db8::1]:12345:/opt/prometheus/config-file.yaml",
                 HTTP_ENABLED,
                 "2001:db8::1",
                 12345,
-                "/opt/prometheus/config-file.yaml"),
+                "/opt/prometheus/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[2001:0db8:0a0b:12f0:0000:0000:0000:0001]:12345:/opt/prometheus/config.yaml",
                 HTTP_ENABLED,
                 "2001:0db8:0a0b:12f0:0000:0000:0000:0001",
                 12345,
-                "/opt/prometheus/config.yaml"),
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[2001:0db8:0a0b:12f0:0000:0000:0000:0001]:12345:/opt/prometheus/config_file.yaml",
                 HTTP_ENABLED,
                 "2001:0db8:0a0b:12f0:0000:0000:0000:0001",
                 12345,
-                "/opt/prometheus/config_file.yaml"),
+                "/opt/prometheus/config_file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[2001:0db8:0a0b:12f0:0000:0000:0000:0001]:12345:/opt/prometheus/config-file.yaml",
                 HTTP_ENABLED,
                 "2001:0db8:0a0b:12f0:0000:0000:0000:0001",
                 12345,
-                "/opt/prometheus/config-file.yaml"),
+                "/opt/prometheus/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[001:0db8:0a0b:12f0:0000:0000:0000:0001]:12345:/opt/prometheus/config.yaml",
                 HTTP_ENABLED,
                 "001:0db8:0a0b:12f0:0000:0000:0000:0001",
                 12345,
-                "/opt/prometheus/config.yaml"),
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[001:0db8:0a0b:12f0:0000:0000:0000:0001]:12345:/opt/prometheus/config_file.yaml",
                 HTTP_ENABLED,
                 "001:0db8:0a0b:12f0:0000:0000:0000:0001",
                 12345,
-                "/opt/prometheus/config_file.yaml"),
+                "/opt/prometheus/config_file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[001:0db8:0a0b:12f0:0000:0000:0000:0001]:12345:/opt/prometheus/config-file.yaml",
                 HTTP_ENABLED,
                 "001:0db8:0a0b:12f0:0000:0000:0000:0001",
                 12345,
-                "/opt/prometheus/config-file.yaml"),
+                "/opt/prometheus/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[001:0db8:0a0b:12f0:0000:0000:0000:0001]:12345:/opt/prometheus/jmx-exporter/config-file.yaml",
                 HTTP_ENABLED,
                 "001:0db8:0a0b:12f0:0000:0000:0000:0001",
                 12345,
-                "/opt/prometheus/jmx-exporter/config-file.yaml"),
+                "/opt/prometheus/jmx-exporter/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[001:0db8:0a0b:12f0:0000:0000:0000:0001]:12345:/opt/prometheus/jmx_exporter/config-file.yaml",
                 HTTP_ENABLED,
                 "001:0db8:0a0b:12f0:0000:0000:0000:0001",
                 12345,
-                "/opt/prometheus/jmx_exporter/config-file.yaml"),
+                "/opt/prometheus/jmx_exporter/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "[001:0db8:0a0b:12f0:0000:0000:0000:0001]:12345:/opt/prometheus/jmx_exporter/config-file.yaml",
                 HTTP_ENABLED,
                 "001:0db8:0a0b:12f0:0000:0000:0000:0001",
                 12345,
-                "/opt/prometheus/jmx_exporter/config-file.yaml"),
+                "/opt/prometheus/jmx_exporter/config-file.yaml",
+                GRACEFUL_DISABLED),
         new ArgumentsTestDefinition(
                 VALID_CONFIGURATION,
                 "/opt/prometheus/config.yaml",
                 HTTP_DISABLED,
                 null,
                 null,
-                "/opt/prometheus/config.yaml"),
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_DISABLED),
+        new ArgumentsTestDefinition(
+                VALID_CONFIGURATION,
+                "graceful:12345:/opt/prometheus/config.yaml",
+                HTTP_ENABLED,
+                "0.0.0.0",
+                12345,
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_ENABLED),
+        new ArgumentsTestDefinition(
+                VALID_CONFIGURATION,
+                "graceful:myhost.domain.com:12345:/opt/prometheus/config.yaml",
+                HTTP_ENABLED,
+                "myhost.domain.com",
+                12345,
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_ENABLED),
+        new ArgumentsTestDefinition(
+                VALID_CONFIGURATION,
+                "graceful:[::1]:12345:/opt/prometheus/config.yaml",
+                HTTP_ENABLED,
+                "::1",
+                12345,
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_ENABLED),
+        new ArgumentsTestDefinition(
+                VALID_CONFIGURATION,
+                "graceful:/opt/prometheus/config.yaml",
+                HTTP_DISABLED,
+                null,
+                null,
+                "/opt/prometheus/config.yaml",
+                GRACEFUL_ENABLED),
+        // Invalid graceful-only string
+        new ArgumentsTestDefinition(
+                INVALID_CONFIGURATION, "graceful:", HTTP_DISABLED, null, null, null, GRACEFUL_ENABLED),
+        // Invalid graceful with invalid port
+        new ArgumentsTestDefinition(
+                INVALID_CONFIGURATION,
+                "graceful:0:/opt/prometheus/config.yaml",
+                HTTP_ENABLED,
+                null,
+                null,
+                null,
+                GRACEFUL_ENABLED),
+
         // Invalid port - port 0
         new ArgumentsTestDefinition(
-                INVALID_CONFIGURATION, "0:/opt/prometheus/config.yaml", HTTP_ENABLED, null, null, null),
+                INVALID_CONFIGURATION,
+                "0:/opt/prometheus/config.yaml",
+                HTTP_ENABLED,
+                null,
+                null,
+                null,
+                GRACEFUL_DISABLED),
         // Invalid port - port 65536
         new ArgumentsTestDefinition(
-                INVALID_CONFIGURATION, "65536:/opt/prometheus/config.yaml", HTTP_ENABLED, null, null, null),
+                INVALID_CONFIGURATION,
+                "65536:/opt/prometheus/config.yaml",
+                HTTP_ENABLED,
+                null,
+                null,
+                null,
+                GRACEFUL_DISABLED),
         // Invalid port - port 99999
         new ArgumentsTestDefinition(
-                INVALID_CONFIGURATION, "99999:/opt/prometheus/config.yaml", HTTP_ENABLED, null, null, null),
+                INVALID_CONFIGURATION,
+                "99999:/opt/prometheus/config.yaml",
+                HTTP_ENABLED,
+                null,
+                null,
+                null,
+                GRACEFUL_DISABLED),
         // Invalid port - host with port 0
         new ArgumentsTestDefinition(
                 INVALID_CONFIGURATION,
@@ -379,7 +494,8 @@ public class ArgumentsTest {
                 HTTP_ENABLED,
                 null,
                 null,
-                null),
+                null,
+                GRACEFUL_DISABLED),
         // Invalid port - host with port 65536
         new ArgumentsTestDefinition(
                 INVALID_CONFIGURATION,
@@ -387,7 +503,8 @@ public class ArgumentsTest {
                 HTTP_ENABLED,
                 null,
                 null,
-                null),
+                null,
+                GRACEFUL_DISABLED),
         // Invalid port - host with port 99999
         new ArgumentsTestDefinition(
                 INVALID_CONFIGURATION,
@@ -395,7 +512,8 @@ public class ArgumentsTest {
                 HTTP_ENABLED,
                 null,
                 null,
-                null),
+                null,
+                GRACEFUL_DISABLED),
         // Invalid port - IPv6 with port 0
         new ArgumentsTestDefinition(
                 INVALID_CONFIGURATION,
@@ -403,7 +521,8 @@ public class ArgumentsTest {
                 HTTP_ENABLED,
                 null,
                 null,
-                null),
+                null,
+                GRACEFUL_DISABLED),
         // Invalid port - IPv6 with port 65536
         new ArgumentsTestDefinition(
                 INVALID_CONFIGURATION,
@@ -411,7 +530,8 @@ public class ArgumentsTest {
                 HTTP_ENABLED,
                 null,
                 null,
-                null),
+                null,
+                GRACEFUL_DISABLED),
         // Invalid port - IPv6 with port 99999
         new ArgumentsTestDefinition(
                 INVALID_CONFIGURATION,
@@ -419,7 +539,8 @@ public class ArgumentsTest {
                 HTTP_ENABLED,
                 null,
                 null,
-                null),
+                null,
+                GRACEFUL_DISABLED),
     };
 
     /**
@@ -481,6 +602,11 @@ public class ArgumentsTest {
         private final String filename;
 
         /**
+         * Expected graceful error handling state.
+         */
+        private final boolean gracefulErrorHandling;
+
+        /**
          * Constructs a test definition with expected parsing results.
          *
          * @param validConfiguration whether the argument is valid
@@ -496,13 +622,15 @@ public class ArgumentsTest {
                 boolean httpEnabled,
                 String host,
                 Integer port,
-                String filename) {
+                String filename,
+                boolean gracefulErrorHandling) {
             this.argument = argument;
             this.validConfiguration = validConfiguration;
             this.httpEnabled = httpEnabled;
             this.host = host;
             this.port = port;
             this.filename = filename;
+            this.gracefulErrorHandling = gracefulErrorHandling;
         }
 
         /**
@@ -519,6 +647,7 @@ public class ArgumentsTest {
                 assertThat(arguments.getHost()).isEqualTo(host);
                 assertThat(arguments.getPort()).isEqualTo(port);
                 assertThat(arguments.getFilename()).isEqualTo(filename);
+                assertThat(arguments.isGracefulErrorHandling()).isEqualTo(gracefulErrorHandling);
             } else {
                 assertThatExceptionOfType(ConfigurationException.class).isThrownBy(() -> Arguments.parse(argument));
             }

--- a/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/JavaAgentTest.java
+++ b/jmx_prometheus_javaagent/src/test/java/io/prometheus/jmx/JavaAgentTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) The Prometheus jmx_exporter Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prometheus.jmx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link JavaAgent} error handling behavior.
+ *
+ * <p>Verifies that the agent exits the JVM in fail-fast mode and keeps running in graceful error
+ * handling mode.
+ */
+public class JavaAgentTest {
+
+    /**
+     * Verifies that graceful error handling does not trigger the exit action.
+     */
+    @Test
+    public void testHandleErrorGracefulDoesNotExit() {
+        AtomicBoolean exited = new AtomicBoolean(false);
+        RuntimeException error = new RuntimeException("boom");
+
+        JavaAgent.handleError(error, null, null, true, code -> exited.set(true));
+
+        assertThat(exited).isFalse();
+    }
+
+    /**
+     * Verifies that fail-fast mode triggers the exit action.
+     */
+    @Test
+    public void testHandleErrorFailFastExits() {
+        AtomicBoolean exited = new AtomicBoolean(false);
+        RuntimeException error = new RuntimeException("boom");
+
+        JavaAgent.handleError(error, null, null, false, code -> exited.set(true));
+
+        assertThat(exited).isTrue();
+    }
+}

--- a/website/docs/deployment/java-agent.md
+++ b/website/docs/deployment/java-agent.md
@@ -17,6 +17,9 @@ The Java agent parses one agent argument string:
 | `<PORT>:<EXPORTER_YAML>` | Enable HTTP on `0.0.0.0:<PORT>`. |
 | `<HOST>:<PORT>:<EXPORTER_YAML>` | Enable HTTP on the specified host and port. |
 | `<EXPORTER_YAML>` | Do not start HTTP; useful for OpenTelemetry-only configuration. |
+| `graceful:<PORT>:<EXPORTER_YAML>` | Enable HTTP on `0.0.0.0:<PORT>`. On startup error, log and clean up without exiting the JVM. |
+| `graceful:<HOST>:<PORT>:<EXPORTER_YAML>` | Enable HTTP on the specified host and port. On startup error, log and clean up without exiting the JVM. |
+| `graceful:<EXPORTER_YAML>` | Do not start HTTP. On startup error, log and clean up without exiting the JVM. |
 
 Ports must be from `1` through `65535`. IPv6 hosts must be enclosed in brackets, for example `[::1]:9404:exporter.yaml`.
 
@@ -62,3 +65,13 @@ rules:
 ## Lifecycle and errors
 
 The agent starts through `premain` at JVM startup or `agentmain` when attached. Startup registers the JMX collector and starts the enabled exporters. Malformed arguments, invalid ports, unreadable YAML, or invalid configuration fail startup.
+
+## Graceful error handling
+
+By default, the Java agent calls `System.exit(1)` when it fails to start, which terminates the JVM. Prefix the agent argument with `graceful:` to disable this behavior for startup errors: the error is still logged and any started resources are closed, but the JVM keeps running.
+
+```bash
+java -javaagent:jmx_prometheus_javaagent-1.6.0.jar=graceful:9404:exporter.yaml -jar your-application.jar
+```
+
+This option only affects startup errors in the Java agent. Scrape and collection errors are unaffected and continue to be reported via the `jmx_scrape_error` metric without terminating the JVM.


### PR DESCRIPTION
Add a `graceful:` agent argument prefix that keeps the JVM running when the JMX exporter fails to start. The error is still logged and any started resources are closed, but System.exit(1) is skipped. Default behavior remains fail-fast for backward compatibility.

This only affects startup errors; scrape-time errors continue to be reported via the jmx_scrape_error metric.