### PR TITLE
fix(isolator): shade embedded classes to prevent logger conflict

### DIFF
--- a/jmx_prometheus_isolator_javaagent/pom.xml
+++ b/jmx_prometheus_isolator_javaagent/pom.xml
@@ -60,6 +60,18 @@
                                     <exclude>org.vafer:jdependency</exclude>
                                 </excludes>
                             </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <shadedPattern>e1723a08afd7bca35570fd31a7656f59.</shadedPattern>
+                                    <includes>
+                                        <include>io.prometheus.jmx.**</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>io.prometheus.jmx.IsolatorJavaAgent</exclude>
+                                        <exclude>io.prometheus.jmx.JavaAgent</exclude>
+                                    </excludes>
+                                </relocation>
+                            </relocations>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>


### PR DESCRIPTION
The jmx_prometheus_isolator_javaagent jar embedded io.prometheus.jmx.logger.* classes without shading them. When an older jmx_prometheus_javaagent jar was also present on the classpath, the system classloader could resolve the older Logger class first, causing a NoSuchMethodError at isolator startup.

Add shade relocations for io.prometheus.jmx.** under the project's standard shaded prefix, while excluding IsolatorJavaAgent (the manifest entry point) and the literal io.prometheus.jmx.JavaAgent class name used by the isolated classloader to start the embedded agent.

Note: the project currently uses a static shade prefix shared across versions. A complete solution that also avoids conflicts between multiple versions of the isolator (or javaagent) on the same classpath would require generating a unique, version-specific prefix at build time and propagating it to JarClassLoader and CustomServiceTransformer.