### PR TITLE
Remove bouncy castle library

### DIFF
--- a/jmx_prometheus_common/pom.xml
+++ b/jmx_prometheus_common/pom.xml
@@ -50,10 +50,6 @@
             <artifactId>ayza-for-pem</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk18on</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
         <altcontainers.version>0.3.0</altcontainers.version>
         <assertj.version>3.27.7</assertj.version>
         <ayza.version>10.0.6</ayza.version>
-        <bouncycastle.version>1.85</bouncycastle.version>
         <caffeine.version>2.9.3</caffeine.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <junit.version>6.1.3</junit.version>
@@ -160,21 +159,6 @@
                 <groupId>io.github.hakky54</groupId>
                 <artifactId>ayza-for-pem</artifactId>
                 <version>${ayza.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk18on</artifactId>
-                <version>${bouncycastle.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk18on</artifactId>
-                <version>${bouncycastle.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcutil-jdk18on</artifactId>
-                <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.yaml</groupId>


### PR DESCRIPTION
In the pull request https://github.com/prometheus/jmx_exporter/pull/1526 I forgot to remove bouncy castle as it is not needed anymore. I was too late to append that commit as it already got merged, so I created this separate pull request. Sorry for the inconvenience 